### PR TITLE
fix: improve upload robustness and crash recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Settings are persisted in `config.json`:
 - `staging_dir`: Local directory for staging images
 - `concurrency_mode`: "auto" or "manual"
 - `concurrency_value`: Number of parallel workers (1-10)
+- `base_url`: Webapp server URL (defaults to `https://find.gfo.rocks`)
 
 ## Architecture
 

--- a/src/api_client.py
+++ b/src/api_client.py
@@ -2,6 +2,8 @@
 API client for communicating with DFN webapp upload endpoints.
 """
 
+import mimetypes
+
 import aiohttp
 from pathlib import Path
 from typing import Optional, Tuple
@@ -82,11 +84,12 @@ class APIClient:
                 data = aiohttp.FormData()
                 data.add_field("key", upload_key)
                 data.add_field("image_type", image_type)
+                content_type = mimetypes.guess_type(file_path.name)[0] or "application/octet-stream"
                 data.add_field(
                     "image",
                     f,
                     filename=file_path.name,
-                    content_type="image/jpeg",
+                    content_type=content_type,
                 )
 
                 async with self.session.post(url, data=data) as response:

--- a/src/state_manager.py
+++ b/src/state_manager.py
@@ -300,6 +300,26 @@ class StateManager:
                 return json.loads(row["value"])
             return default
 
+    def reset_stuck_uploading(self) -> int:
+        """Reset any images stuck in 'uploading' status back to 'staged'.
+
+        This is a crash-recovery mechanism: if the app exits while images
+        are mid-upload, those images would otherwise be permanently stuck
+        since get_staged_images() only queries status='staged'.
+
+        Returns:
+            Number of images that were reset.
+        """
+        with self.transaction() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE images
+                SET status = 'staged', error_message = NULL
+                WHERE status = 'uploading'
+                """
+            )
+            return cursor.rowcount
+
     def delete_uploaded_image_record(self, image_id: int):
         """Delete an uploaded image record (for cleanup)."""
         with self.transaction() as conn:

--- a/src/upload_manager.py
+++ b/src/upload_manager.py
@@ -200,6 +200,16 @@ class UploadManager(QThread):
                     # Upload failed
                     logger.warning(f"Upload attempt {attempt + 1} failed for {filename}: {message}")
 
+                    # Don't retry permanent failures (4xx responses)
+                    if self._is_permanent_failure(message):
+                        logger.warning(f"Permanent failure for {filename}, not retrying: {message}")
+                        self.state_manager.increment_retry_count(image_id)
+                        self.state_manager.update_image_status(
+                            image_id, "failed", f"Upload failed: {message}"
+                        )
+                        self.upload_failed.emit(filename, message)
+                        return False
+
                     if attempt < self.MAX_RETRIES - 1:
                         # Wait before retry with exponential backoff
                         delay = self.RETRY_BASE_DELAY * (2**attempt)
@@ -250,8 +260,26 @@ class UploadManager(QThread):
 
             queue.task_done()
 
+    @staticmethod
+    def _is_permanent_failure(message: str) -> bool:
+        """Check if an upload failure is permanent and should not be retried.
+
+        Permanent failures include HTTP 4xx responses (bad request, not found,
+        forbidden, etc.) which indicate client-side errors that won't resolve
+        on retry.
+        """
+        return message.startswith("HTTP 4")
+
     async def _upload_loop(self):
         """Main upload loop."""
+        # Crash recovery: reset any images stuck in 'uploading' from a
+        # previous run that crashed or was killed mid-flight.
+        reset_count = self.state_manager.reset_stuck_uploading()
+        if reset_count > 0:
+            logger.info(
+                f"Reset {reset_count} images from 'uploading' back to 'staged' (crash recovery)"
+            )
+
         async with APIClient(self.base_url) as client:
             while not self._should_stop:
                 # Get staged images

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -1205,6 +1205,13 @@ class UploaderWindow(QMainWindow):
             )
             return
 
+        # Crash recovery: reset any images stuck in 'uploading' from a
+        # previous run that crashed or was killed mid-flight.
+        reset_count = self.state_manager.reset_stuck_uploading()
+        if reset_count > 0:
+            self.log(f"Recovered {reset_count} image(s) stuck from a previous session")
+            self.update_counts()
+
         counts = self.state_manager.get_image_counts()
         if counts.get("staged", 0) == 0:
             QMessageBox.information(
@@ -1215,7 +1222,10 @@ class UploaderWindow(QMainWindow):
             return
 
         # Start upload thread
-        self.upload_thread = UploadManager(upload_key, self.state_manager, self.stats_tracker)
+        base_url = self.config.get("base_url", "https://find.gfo.rocks")
+        self.upload_thread = UploadManager(
+            upload_key, self.state_manager, self.stats_tracker, base_url=base_url
+        )
 
         if self.auto_radio.isChecked():
             self.upload_thread.set_auto_optimize(True)

--- a/tests/integration/test_upload_retry.py
+++ b/tests/integration/test_upload_retry.py
@@ -4,6 +4,8 @@ Integration test: Upload failures with retry logic.
 Covers:
 - Transient server errors (HTTP 500) that succeed after retries
 - Permanent failures that exhaust all retry attempts
+- Permanent failures (4xx) that skip retries entirely
+- Crash recovery of images stuck in 'uploading' status
 - Using the "Retry Selected" button in the Failed Uploads tab
 """
 
@@ -222,3 +224,182 @@ class TestRetryFromGUI:
         counts = integration_state_manager.get_image_counts()
         assert counts["uploaded"] == 1
         assert counts["failed"] == 0
+
+
+class TestPermanentFailureNoRetry:
+    """4xx errors should fail immediately without retrying."""
+
+    def test_http_404_fails_immediately_no_retries(
+        self,
+        qtbot,
+        app_window,
+        upload_key,
+        integration_state_manager,
+        staging_dir,
+    ):
+        """
+        When the server returns HTTP 404 (invalid upload key), the image
+        should be marked failed immediately without burning through 5 retries.
+        Only 1 upload attempt should be made.
+        """
+        _pre_stage_images(integration_state_manager, staging_dir, n=1)
+        window = app_window
+
+        window.manual_radio.setChecked(True)
+        window.worker_spin.setValue(1)
+
+        with aioresponses() as m:
+            m.post(CHECK_URL, status=200, body="0")
+            # Only register 1 response — if the client retries, it will
+            # get a ConnectionError (no more registered responses), which
+            # would cause a different failure mode.
+            m.post(UPLOAD_URL, status=404, body="Not Found")
+
+            qtbot.mouseClick(window.upload_start_btn, Qt.MouseButton.LeftButton)
+            wait_for_thread_done(qtbot, lambda: window.upload_thread, timeout=30_000)
+            process_events()
+
+        counts = integration_state_manager.get_image_counts()
+        assert counts["failed"] == 1
+        assert counts["uploaded"] == 0
+
+        failed = integration_state_manager.get_failed_images()
+        assert len(failed) == 1
+        assert "404" in failed[0]["error_message"]
+
+    def test_http_400_fails_immediately_no_retries(
+        self,
+        qtbot,
+        app_window,
+        upload_key,
+        integration_state_manager,
+        staging_dir,
+    ):
+        """HTTP 400 (bad request) is permanent — no retries."""
+        _pre_stage_images(integration_state_manager, staging_dir, n=1)
+        window = app_window
+
+        window.manual_radio.setChecked(True)
+        window.worker_spin.setValue(1)
+
+        with aioresponses() as m:
+            m.post(CHECK_URL, status=200, body="0")
+            m.post(UPLOAD_URL, status=400, body="Bad Request")
+
+            qtbot.mouseClick(window.upload_start_btn, Qt.MouseButton.LeftButton)
+            wait_for_thread_done(qtbot, lambda: window.upload_thread, timeout=30_000)
+            process_events()
+
+        counts = integration_state_manager.get_image_counts()
+        assert counts["failed"] == 1
+        assert counts["uploaded"] == 0
+
+    def test_http_500_still_retries(
+        self,
+        qtbot,
+        app_window,
+        upload_key,
+        integration_state_manager,
+        staging_dir,
+    ):
+        """HTTP 500 is transient — should retry and eventually succeed."""
+        _pre_stage_images(integration_state_manager, staging_dir, n=1)
+        window = app_window
+
+        window.manual_radio.setChecked(True)
+        window.worker_spin.setValue(1)
+
+        with aioresponses() as m:
+            m.post(CHECK_URL, status=200, body="0")
+            m.post(UPLOAD_URL, status=500, body="Internal Server Error")
+            m.post(UPLOAD_URL, status=200, body="SUCCESS")
+
+            qtbot.mouseClick(window.upload_start_btn, Qt.MouseButton.LeftButton)
+            wait_for_thread_done(qtbot, lambda: window.upload_thread, timeout=30_000)
+            process_events()
+
+        counts = integration_state_manager.get_image_counts()
+        assert counts["uploaded"] == 1
+        assert counts["failed"] == 0
+
+
+class TestCrashRecovery:
+    """Images stuck in 'uploading' from a previous crash are recovered."""
+
+    def test_stuck_uploading_images_are_recovered_and_uploaded(
+        self,
+        qtbot,
+        app_window,
+        upload_key,
+        integration_state_manager,
+        staging_dir,
+    ):
+        """
+        Simulate a crash by pre-setting images to 'uploading' status directly
+        in the DB. When the upload loop starts, it should reset them to 'staged'
+        and then upload them normally.
+        """
+        # Pre-stage images normally first, then force them to 'uploading'
+        images = _pre_stage_images(integration_state_manager, staging_dir, n=2)
+        for img in images:
+            integration_state_manager.update_image_status(img["id"], "uploading")
+
+        counts = integration_state_manager.get_image_counts()
+        assert counts.get("uploading", 0) == 2
+        assert counts.get("staged", 0) == 0
+
+        window = app_window
+
+        window.manual_radio.setChecked(True)
+        window.worker_spin.setValue(1)
+
+        with aioresponses() as m:
+            for _ in range(2):
+                m.post(CHECK_URL, status=200, body="0")
+                m.post(UPLOAD_URL, status=200, body="SUCCESS")
+
+            qtbot.mouseClick(window.upload_start_btn, Qt.MouseButton.LeftButton)
+            wait_for_thread_done(qtbot, lambda: window.upload_thread, timeout=30_000)
+            process_events()
+
+        counts = integration_state_manager.get_image_counts()
+        assert counts["uploaded"] == 2
+        assert counts.get("uploading", 0) == 0
+        assert counts.get("staged", 0) == 0
+
+    def test_mix_of_stuck_and_staged_images(
+        self,
+        qtbot,
+        app_window,
+        upload_key,
+        integration_state_manager,
+        staging_dir,
+    ):
+        """
+        Mix of stuck-uploading and normally-staged images should all be uploaded.
+        """
+        images = _pre_stage_images(integration_state_manager, staging_dir, n=3)
+        # Mark first image as stuck in 'uploading'
+        integration_state_manager.update_image_status(images[0]["id"], "uploading")
+
+        counts = integration_state_manager.get_image_counts()
+        assert counts.get("uploading", 0) == 1
+        assert counts.get("staged", 0) == 2
+
+        window = app_window
+
+        window.manual_radio.setChecked(True)
+        window.worker_spin.setValue(1)
+
+        with aioresponses() as m:
+            for _ in range(3):
+                m.post(CHECK_URL, status=200, body="0")
+                m.post(UPLOAD_URL, status=200, body="SUCCESS")
+
+            qtbot.mouseClick(window.upload_start_btn, Qt.MouseButton.LeftButton)
+            wait_for_thread_done(qtbot, lambda: window.upload_thread, timeout=30_000)
+            process_events()
+
+        counts = integration_state_manager.get_image_counts()
+        assert counts["uploaded"] == 3
+        assert counts.get("uploading", 0) == 0

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -141,3 +141,77 @@ async def test_custom_base_url():
         async with APIClient("https://custom.example.com") as client:
             result = await client.check_image_uploaded("test-key", "test.jpg")
             assert result is False
+
+
+@pytest.mark.asyncio
+async def test_upload_image_uses_correct_mime_type_for_png(tmp_path):
+    """Upload of a .png file should use content_type='image/png', not 'image/jpeg'."""
+    from PIL import Image as PILImage
+
+    png_file = tmp_path / "test_image.png"
+    PILImage.new("RGB", (100, 100), color="red").save(png_file, "PNG")
+
+    captured_content_type = None
+    original_add_field = aiohttp.FormData.add_field
+
+    def patched_add_field(self, name, value, **kwargs):
+        nonlocal captured_content_type
+        if name == "image":
+            captured_content_type = kwargs.get("content_type")
+        return original_add_field(self, name, value, **kwargs)
+
+    with aioresponses() as m:
+        m.post(UPLOAD_URL, status=200, body="SUCCESS")
+        with patch.object(aiohttp.FormData, "add_field", patched_add_field):
+            async with APIClient() as client:
+                success, message = await client.upload_image("test-key", "survey", png_file)
+                assert success is True
+
+    assert captured_content_type == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_upload_image_uses_jpeg_mime_for_jpg(sample_image):
+    """Upload of a .jpg file should use content_type='image/jpeg'."""
+    captured_content_type = None
+    original_add_field = aiohttp.FormData.add_field
+
+    def patched_add_field(self, name, value, **kwargs):
+        nonlocal captured_content_type
+        if name == "image":
+            captured_content_type = kwargs.get("content_type")
+        return original_add_field(self, name, value, **kwargs)
+
+    with aioresponses() as m:
+        m.post(UPLOAD_URL, status=200, body="SUCCESS")
+        with patch.object(aiohttp.FormData, "add_field", patched_add_field):
+            async with APIClient() as client:
+                success, message = await client.upload_image("test-key", "survey", sample_image)
+                assert success is True
+
+    assert captured_content_type == "image/jpeg"
+
+
+@pytest.mark.asyncio
+async def test_upload_image_unknown_extension_uses_octet_stream(tmp_path):
+    """Upload of a file with unknown extension falls back to application/octet-stream."""
+    unknown_file = tmp_path / "test_image.xyz123"
+    unknown_file.write_bytes(b"some binary data")
+
+    captured_content_type = None
+    original_add_field = aiohttp.FormData.add_field
+
+    def patched_add_field(self, name, value, **kwargs):
+        nonlocal captured_content_type
+        if name == "image":
+            captured_content_type = kwargs.get("content_type")
+        return original_add_field(self, name, value, **kwargs)
+
+    with aioresponses() as m:
+        m.post(UPLOAD_URL, status=200, body="SUCCESS")
+        with patch.object(aiohttp.FormData, "add_field", patched_add_field):
+            async with APIClient() as client:
+                success, message = await client.upload_image("test-key", "survey", unknown_file)
+                assert success is True
+
+    assert captured_content_type == "application/octet-stream"

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -159,3 +159,39 @@ def test_increment_retry_count(mock_state_manager):
     staged = mock_state_manager.get_staged_images()
     row = next(i for i in staged if i["filename"] == "retry_unique_abc.jpg")
     assert row["retry_count"] == 2
+
+
+def test_reset_stuck_uploading(mock_state_manager):
+    """reset_stuck_uploading moves 'uploading' images back to 'staged'."""
+    id1 = mock_state_manager.add_image("stuck1.jpg", "/tmp/stuck1.jpg", "survey")
+    id2 = mock_state_manager.add_image("stuck2.jpg", "/tmp/stuck2.jpg", "survey")
+    id3 = mock_state_manager.add_image("ok.jpg", "/tmp/ok.jpg", "survey")
+
+    mock_state_manager.update_image_status(id1, "uploading")
+    mock_state_manager.update_image_status(id2, "uploading")
+    # id3 stays 'staged'
+
+    reset_count = mock_state_manager.reset_stuck_uploading()
+    assert reset_count == 2
+
+    counts = mock_state_manager.get_image_counts()
+    assert counts["staged"] == 3
+    assert counts.get("uploading", 0) == 0
+
+
+def test_reset_stuck_uploading_clears_error_message(mock_state_manager):
+    """reset_stuck_uploading clears any error_message on reset images."""
+    image_id = mock_state_manager.add_image("err.jpg", "/tmp/err.jpg", "survey")
+    mock_state_manager.update_image_status(image_id, "uploading", "partial upload")
+
+    mock_state_manager.reset_stuck_uploading()
+
+    staged = mock_state_manager.get_staged_images()
+    row = next(i for i in staged if i["filename"] == "err.jpg")
+    assert row is not None
+
+
+def test_reset_stuck_uploading_returns_zero_when_none(mock_state_manager):
+    """reset_stuck_uploading returns 0 when no images are stuck."""
+    mock_state_manager.add_image("fine.jpg", "/tmp/fine.jpg", "survey")
+    assert mock_state_manager.reset_stuck_uploading() == 0

--- a/tests/test_upload_manager.py
+++ b/tests/test_upload_manager.py
@@ -171,3 +171,34 @@ class TestAdjustWorkerCount:
 
         assert manager.last_measurement_bytes == 500_000
         assert manager.last_measurement_time == pytest.approx(time.time(), abs=1.0)
+
+
+# ---------------------------------------------------------------------------
+# _is_permanent_failure
+# ---------------------------------------------------------------------------
+
+
+class TestIsPermanentFailure:
+    def test_http_400_is_permanent(self, manager):
+        assert manager._is_permanent_failure("HTTP 400: Bad Request") is True
+
+    def test_http_404_is_permanent(self, manager):
+        assert manager._is_permanent_failure("HTTP 404: Not Found") is True
+
+    def test_http_403_is_permanent(self, manager):
+        assert manager._is_permanent_failure("HTTP 403: Forbidden") is True
+
+    def test_http_422_is_permanent(self, manager):
+        assert manager._is_permanent_failure("HTTP 422: Unprocessable Entity") is True
+
+    def test_http_500_is_not_permanent(self, manager):
+        assert manager._is_permanent_failure("HTTP 500: Internal Server Error") is False
+
+    def test_http_502_is_not_permanent(self, manager):
+        assert manager._is_permanent_failure("HTTP 502: Bad Gateway") is False
+
+    def test_network_error_is_not_permanent(self, manager):
+        assert manager._is_permanent_failure("connection refused") is False
+
+    def test_error_body_is_not_permanent(self, manager):
+        assert manager._is_permanent_failure("ERROR - something") is False


### PR DESCRIPTION
- Add crash recovery: images stuck in 'uploading' from a previous session are automatically reset to 'staged' when the upload starts, so they are retried rather than silently abandoned
- Skip retries for permanent HTTP 4xx failures (e.g. invalid upload key), so the app fails fast rather than waiting through multiple backoff delays before surfacing the error
- Use the actual file MIME type when uploading rather than hardcoding image/jpeg, ensuring correct content-type for non-JPEG formats
- Expose the server base URL as an optional config key so it can be overridden for non-standard deployments without rebuilding the app
- Update documentation to reflect the new configuration option
- Add tests covering all new behaviour