### PR TITLE
feat: split SD card copy into optional copy + separate staging step

### DIFF
--- a/src/sd_monitor.py
+++ b/src/sd_monitor.py
@@ -3,8 +3,10 @@ Cross-platform SD card detection and monitoring.
 """
 
 import psutil
+import subprocess
+import sys
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Tuple
 import logging
 
 logger = logging.getLogger(__name__)
@@ -59,6 +61,109 @@ class SDCardInfo:
 
     def __repr__(self):
         return f"SDCardInfo(path={self.path}, total={self.total_gb:.1f}GB, images={self.count_images()})"
+
+
+def eject_device(mount_point: str) -> Tuple[bool, str]:
+    """
+    Attempt to eject / unmount a removable device.
+
+    Args:
+        mount_point: The mount path of the device (e.g. /media/user/SDCARD).
+
+    Returns:
+        (success, message) — success is True if the eject command succeeded,
+        message contains the output or error details.
+    """
+    mount_point = str(mount_point)
+    try:
+        if sys.platform.startswith("linux"):
+            # The mount point might disappear from psutil after unmounting,
+            # so we must determine the block device path beforehand.
+            dev_path = _device_for_mount(mount_point)
+
+            # Try udisksctl first (most desktop Linux distros)
+            result = subprocess.run(
+                ["udisksctl", "unmount", "-b", dev_path],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode == 0:
+                # Now power-off the drive
+                power_off_result = subprocess.run(
+                    ["udisksctl", "power-off", "-b", dev_path],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                if power_off_result.returncode == 0:
+                    return True, "SD card ejected successfully. You can safely remove it."
+                warning_msg = (
+                    "SD card was unmounted, but powering off the device failed: "
+                    f"{power_off_result.stderr.strip()}"
+                )
+                logger.warning(warning_msg)
+                return False, warning_msg
+            # Fallback to umount
+            result = subprocess.run(
+                ["umount", mount_point],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode == 0:
+                return True, "SD card unmounted. You can safely remove it."
+            return False, f"Could not eject: {result.stderr.strip()}"
+
+        elif sys.platform == "darwin":
+            result = subprocess.run(
+                ["diskutil", "eject", mount_point],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode == 0:
+                return True, "SD card ejected successfully. You can safely remove it."
+            return False, f"Could not eject: {result.stderr.strip()}"
+
+        elif sys.platform == "win32":
+            # Use PowerShell to eject removable drive
+            drive_letter = mount_point[0]
+            ps_script = (
+                f"$driveEject = New-Object -comObject Shell.Application; "
+                f'$driveEject.Namespace(17).ParseName("{drive_letter}:").InvokeVerb("Eject")'
+            )
+            result = subprocess.run(
+                ["powershell", "-Command", ps_script],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode == 0:
+                return True, "SD card ejected successfully. You can safely remove it."
+            return False, f"Could not eject: {result.stderr.strip()}"
+
+        else:
+            return False, f"Eject not supported on this platform ({sys.platform})."
+
+    except FileNotFoundError as e:
+        return False, f"Eject tool not found: {e}"
+    except subprocess.TimeoutExpired:
+        return False, "Eject timed out. The SD card may be busy."
+    except Exception as e:
+        return False, f"Eject failed: {e}"
+
+
+def _device_for_mount(mount_point: str) -> str:
+    """Find the block device path for a given mount point."""
+    try:
+        partitions = psutil.disk_partitions(all=False)
+        for p in partitions:
+            if p.mountpoint == mount_point:
+                return p.device
+    except Exception:
+        pass
+    return mount_point
 
 
 class SDMonitor:

--- a/src/staging.py
+++ b/src/staging.py
@@ -1,11 +1,11 @@
 """
-Image staging from SD cards to local storage with retry logic.
+Image staging: file copy from SD cards and folder scanning for DB registration.
 """
 
 import shutil
 import time
 from pathlib import Path
-from typing import Optional, Callable
+from typing import Optional, List
 from datetime import datetime
 from PySide6.QtCore import QThread, Signal
 from PIL import Image
@@ -14,14 +14,54 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Common image extensions
+IMAGE_EXTENSIONS = {".jpg", ".JPG", ".jpeg", ".JPEG"}
+
+
+def _extract_exif_timestamp(image_path: Path) -> Optional[str]:
+    """
+    Extract EXIF DateTimeOriginal from image.
+
+    Args:
+        image_path: Path to the image file
+
+    Returns:
+        ISO format timestamp string, or None if not available
+    """
+    try:
+        with Image.open(image_path) as img:
+            exif = img.getexif()
+            if exif and 36867 in exif:  # DateTimeOriginal tag
+                # EXIF datetime format is "YYYY:MM:DD HH:MM:SS"
+                exif_time = exif[36867]
+                # Convert to ISO format
+                dt = datetime.strptime(exif_time, "%Y:%m:%d %H:%M:%S")
+                return dt.isoformat()
+    except Exception as e:
+        logger.warning(f"Could not extract EXIF timestamp from {image_path.name}: {e}")
+
+    # Fallback to file modification time
+    try:
+        mtime = image_path.stat().st_mtime
+        dt = datetime.fromtimestamp(mtime)
+        return dt.isoformat()
+    except Exception as e:
+        logger.warning(f"Could not get file mtime for {image_path.name}: {e}")
+
+    return None
+
 
 class StagingCopier(QThread):
-    """Thread for copying images from SD card to staging directory."""
+    """Thread for copying images from a source folder to the staging directory.
+
+    This is a pure file copy — no database registration happens here.
+    That is handled separately by FolderScanner.
+    """
 
     # Signals
     progress = Signal(int, int, str)  # current_file, total_files, current_filename
     speed_update = Signal(float)  # bytes per second
-    finished = Signal(int, int)  # successful_count, failed_count
+    finished = Signal(int, int, int, bool)  # successful_count, failed_count, skipped_count, aborted
     error = Signal(str, str)  # filename, error_message
     disk_space_warning = Signal(float)  # GB remaining
     disk_space_critical = Signal(float)  # GB remaining
@@ -34,21 +74,25 @@ class StagingCopier(QThread):
 
     def __init__(
         self,
-        sd_card_path: Path,
+        source_path: Path,
         staging_dir: Path,
-        image_type: str,
-        state_manager,
+        delete_source: bool = False,
     ):
         super().__init__()
-        self.sd_card_path = Path(sd_card_path)
+        self.source_path = Path(source_path)
         self.staging_dir = Path(staging_dir)
-        self.image_type = image_type
-        self.state_manager = state_manager
+        self.delete_source = delete_source
         self._should_stop = False
+        self._copied_files: List[Path] = []
 
     def stop(self):
         """Request the thread to stop."""
         self._should_stop = True
+
+    @property
+    def copied_files(self) -> List[Path]:
+        """Files that were successfully copied (available after thread finishes)."""
+        return self._copied_files
 
     def _check_disk_space(self) -> bool:
         """
@@ -73,36 +117,8 @@ class StagingCopier(QThread):
             return True  # Continue on error
 
     def _extract_exif_timestamp(self, image_path: Path) -> Optional[str]:
-        """
-        Extract EXIF DateTimeOriginal from image.
-
-        Args:
-            image_path: Path to the image file
-
-        Returns:
-            ISO format timestamp string, or None if not available
-        """
-        try:
-            with Image.open(image_path) as img:
-                exif = img.getexif()
-                if exif and 36867 in exif:  # DateTimeOriginal tag
-                    # EXIF datetime format is "YYYY:MM:DD HH:MM:SS"
-                    exif_time = exif[36867]
-                    # Convert to ISO format
-                    dt = datetime.strptime(exif_time, "%Y:%m:%d %H:%M:%S")
-                    return dt.isoformat()
-        except Exception as e:
-            logger.warning(f"Could not extract EXIF timestamp from {image_path.name}: {e}")
-
-        # Fallback to file modification time
-        try:
-            mtime = image_path.stat().st_mtime
-            dt = datetime.fromtimestamp(mtime)
-            return dt.isoformat()
-        except Exception as e:
-            logger.warning(f"Could not get file mtime for {image_path.name}: {e}")
-
-        return None
+        """Extract EXIF DateTimeOriginal from image (delegates to module-level function)."""
+        return _extract_exif_timestamp(image_path)
 
     def _copy_file_with_retry(self, src: Path, dst: Path) -> bool:
         """
@@ -154,99 +170,213 @@ class StagingCopier(QThread):
             self.staging_dir.mkdir(parents=True, exist_ok=True)
 
             # Get list of images
-            image_extensions = {".jpg", ".JPG", ".jpeg", ".JPEG"}
-            images = []
-            for ext in image_extensions:
-                images.extend(self.sd_card_path.rglob(f"*{ext}"))
+            image_paths = []
+            for ext in {e.lower() for e in IMAGE_EXTENSIONS}:
+                # Generate case=insensitive pattern e.g. .jpg -> .[jJ][pP][gG]
+                pattern = (
+                    f"*{''.join(f'[{c.lower()}{c.upper()}]' if c.isalpha() else c for c in ext)}"
+                )
+                image_paths.extend(self.source_path.rglob(pattern))
+
+            # De-duplicate while preserving order, and ensure we only keep files
+            images = [p for p in dict.fromkeys(image_paths) if p.is_file()]
 
             total_files = len(images)
             if total_files == 0:
-                logger.info("No images found on SD card")
-                self.finished.emit(0, 0)
+                logger.info("No images found in source folder")
+                self.finished.emit(0, 0, 0, False)
                 return
 
             successful = 0
             failed = 0
+            skipped = 0
             total_bytes = 0
             start_time = time.time()
 
+            aborted = False
             for idx, src_path in enumerate(images):
                 if self._should_stop:
                     logger.info("Staging stopped by user")
+                    aborted = True
                     break
 
                 # Check disk space before each file
                 if not self._check_disk_space():
                     logger.error("Insufficient disk space, stopping copy")
+                    aborted = True
                     break
 
                 # Emit progress
                 self.progress.emit(idx + 1, total_files, src_path.name)
 
-                # Destination path (preserve filename)
-                dst_path = self.staging_dir / src_path.name
+                # Destination path (preserve relative directory structure)
+                try:
+                    rel_path = src_path.relative_to(self.source_path)
+                except ValueError:
+                    # Fallback to just filename if relative_to fails
+                    rel_path = Path(src_path.name)
+
+                dst_path = self.staging_dir / rel_path
+
+                # Ensure parent directory exists
+                dst_path.parent.mkdir(parents=True, exist_ok=True)
 
                 # Skip if already exists
                 if dst_path.exists():
-                    logger.info(f"Skipping {src_path.name}, already staged")
-                    successful += 1
+                    logger.info(f"Skipping {src_path.name}, already in staging folder")
+                    skipped += 1
+                    # Delete source if requested and files appear identical (size match)
+                    if self.delete_source:
+                        try:
+                            src_size = src_path.stat().st_size
+                            dst_size = dst_path.stat().st_size
+                            if src_size == dst_size:
+                                try:
+                                    src_path.unlink()
+                                    logger.info(
+                                        f"Deleted source {src_path.name} after skip (size match)"
+                                    )
+                                except Exception as e:
+                                    logger.warning(
+                                        f"Could not delete source {src_path.name} after skip: {e}"
+                                    )
+                            else:
+                                logger.warning(
+                                    f"Not deleting source {src_path.name} after skip: size mismatch "
+                                    f"(source={src_size}, dest={dst_size})"
+                                )
+                        except Exception as e:
+                            logger.warning(
+                                f"Not deleting source {src_path.name} after skip: could not stat files: {e}"
+                            )
                     continue
 
                 # Copy with retry
                 if self._copy_file_with_retry(src_path, dst_path):
-                    # Extract EXIF timestamp
-                    exif_timestamp = self._extract_exif_timestamp(dst_path)
-
-                    # Get file size
                     file_size = dst_path.stat().st_size
+                    successful += 1
+                    total_bytes += file_size
+                    self._copied_files.append(dst_path)
 
-                    # Add to database
-                    try:
-                        self.state_manager.add_image(
-                            filename=dst_path.name,
-                            staging_path=str(dst_path),
-                            image_type=self.image_type,
-                            exif_timestamp=exif_timestamp,
-                            file_size=file_size,
-                        )
-                        successful += 1
-                        total_bytes += file_size
+                    # Calculate and emit speed
+                    elapsed = time.time() - start_time
+                    if elapsed > 0:
+                        speed = total_bytes / elapsed
+                        self.speed_update.emit(speed)
 
-                        # Calculate and emit speed
-                        elapsed = time.time() - start_time
-                        if elapsed > 0:
-                            speed = total_bytes / elapsed
-                            self.speed_update.emit(speed)
-
-                    except Exception as e:
-                        logger.error(f"Error adding {dst_path.name} to database: {e}")
-                        self.error.emit(dst_path.name, str(e))
-                        failed += 1
-                        # Clean up the copied file
-                        if dst_path.exists():
-                            dst_path.unlink()
+                    # Delete source file if requested
+                    if self.delete_source:
+                        try:
+                            src_path.unlink()
+                        except Exception as e:
+                            logger.warning(f"Could not delete source {src_path.name}: {e}")
                 else:
                     # All retries failed
                     error_msg = f"Failed to copy after {self.MAX_RETRIES} attempts"
                     logger.error(f"{src_path.name}: {error_msg}")
                     self.error.emit(src_path.name, error_msg)
-
-                    # Record staging failure
-                    try:
-                        self.state_manager.add_staging_failure(
-                            filename=src_path.name,
-                            sd_card_path=str(src_path),
-                            error_message=error_msg,
-                            retry_attempts=self.MAX_RETRIES,
-                        )
-                    except Exception as e:
-                        logger.error(f"Error recording staging failure: {e}")
-
                     failed += 1
 
-            self.finished.emit(successful, failed)
+            self.finished.emit(successful, failed, skipped, aborted)
 
         except Exception as e:
             logger.error(f"Staging thread error: {e}", exc_info=True)
             self.error.emit("THREAD_ERROR", str(e))
-            self.finished.emit(0, 0)
+            self.finished.emit(0, 0, 0, True)
+
+
+class FolderScanner(QThread):
+    """Thread for scanning a staging folder and registering un-tracked images in the database.
+
+    Images already present in the DB (by staging_path) are skipped.
+    """
+
+    # Signals
+    progress = Signal(int, int, str)  # current_file, total_files, current_filename
+    finished = Signal(int, int, int)  # registered_count, skipped_count, failed_count
+
+    def __init__(
+        self,
+        staging_dir: Path,
+        image_type: str,
+        state_manager,
+    ):
+        super().__init__()
+        self.staging_dir = Path(staging_dir)
+        self.image_type = image_type
+        self.state_manager = state_manager
+        self._should_stop = False
+
+    def stop(self):
+        """Request the thread to stop."""
+        self._should_stop = True
+
+    def run(self):
+        """Scan staging folder and register new images in the database."""
+        try:
+            # Collect all images in the staging directory
+            image_paths = []
+            for ext in {e.lower() for e in IMAGE_EXTENSIONS}:
+                pattern = (
+                    f"*{''.join(f'[{c.lower()}{c.upper()}]' if c.isalpha() else c for c in ext)}"
+                )
+                image_paths.extend(self.staging_dir.rglob(pattern))
+
+            # De-duplicate while preserving order, and ensure we only keep files
+            images = [p for p in dict.fromkeys(image_paths) if p.is_file()]
+
+            total_files = len(images)
+            if total_files == 0:
+                logger.info("No images found in staging folder")
+                self.finished.emit(0, 0, 0)
+                return
+
+            registered = 0
+            skipped = 0
+            failed = 0
+
+            # Pre-fetch all known staging paths to avoid N+1 DB queries
+            existing_paths = self.state_manager.get_all_staging_paths()
+
+            for idx, img_path in enumerate(images):
+                if self._should_stop:
+                    logger.info("Folder scan stopped by user")
+                    break
+
+                self.progress.emit(idx + 1, total_files, img_path.name)
+
+                staging_path_str = str(img_path)
+
+                # Skip if already in DB (O(1) in-memory lookup)
+                if staging_path_str in existing_paths:
+                    skipped += 1
+                    continue
+
+                # Extract EXIF timestamp
+                exif_timestamp = _extract_exif_timestamp(img_path)
+
+                # Get file size
+                try:
+                    file_size = img_path.stat().st_size
+                except OSError:
+                    file_size = None
+
+                # Register in database
+                try:
+                    self.state_manager.add_image(
+                        filename=img_path.name,
+                        staging_path=staging_path_str,
+                        image_type=self.image_type,
+                        exif_timestamp=exif_timestamp,
+                        file_size=file_size,
+                    )
+                    registered += 1
+                except Exception as e:
+                    logger.error(f"Error registering {img_path.name} in database: {e}")
+                    failed += 1
+
+            self.finished.emit(registered, skipped, failed)
+
+        except Exception as e:
+            logger.error(f"Folder scan error: {e}", exc_info=True)
+            self.finished.emit(0, 0, 0)

--- a/src/state_manager.py
+++ b/src/state_manager.py
@@ -320,6 +320,23 @@ class StateManager:
             )
             return cursor.rowcount
 
+    def image_exists_by_path(self, staging_path: str) -> bool:
+        """Check if an image with the given staging path already exists in the database."""
+        with self.transaction() as conn:
+            cursor = conn.execute(
+                """
+                SELECT 1 FROM images WHERE staging_path = ? LIMIT 1
+                """,
+                (staging_path,),
+            )
+            return cursor.fetchone() is not None
+
+    def get_all_staging_paths(self) -> set:
+        """Return a set of all staging_path values in the images table (any status)."""
+        with self.transaction() as conn:
+            cursor = conn.execute("SELECT staging_path FROM images")
+            return {row[0] for row in cursor.fetchall()}
+
     def delete_uploaded_image_record(self, image_id: int):
         """Delete an uploaded image record (for cleanup)."""
         with self.transaction() as conn:

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -24,6 +24,7 @@ from PySide6.QtWidgets import (
     QRadioButton,
     QButtonGroup,
     QComboBox,
+    QCheckBox,
     QFileDialog,
     QMessageBox,
     QTabWidget,
@@ -35,14 +36,14 @@ from PySide6.QtWidgets import (
     QScrollArea,
     QSizePolicy,
 )
-from PySide6.QtCore import QTimer, Qt
+from PySide6.QtCore import QTimer, QThread, Signal, Qt
 from PySide6.QtGui import QFont, QColor
 import psutil
 import logging
 
 from .state_manager import StateManager
-from .sd_monitor import SDMonitor
-from .staging import StagingCopier
+from .sd_monitor import SDMonitor, eject_device
+from .staging import StagingCopier, FolderScanner
 from .upload_manager import UploadManager
 from .stats_tracker import StatsTracker
 
@@ -103,19 +104,79 @@ _BANNER_COLORS = {
     "READY": {"dark": "#48484A", "light": "#C7C7CC"},
     "COPYING": {"dark": "#0A84FF", "light": "#0A84FF"},
     "DONE_COPYING": {"dark": "#30D158", "light": "#30D158"},
+    "STAGING": {"dark": "#0A84FF", "light": "#0A84FF"},
+    "DONE_STAGING": {"dark": "#30D158", "light": "#30D158"},
     "UPLOADING": {"dark": "#0A84FF", "light": "#0A84FF"},
     "PAUSED": {"dark": "#FF9F0A", "light": "#FF9F0A"},
     "COMPLETE": {"dark": "#30D158", "light": "#30D158"},
 }
 
 _BANNER_TEXT = {
-    "READY": "Ready — Insert an SD card and follow the steps below",
+    "READY": "Ready — follow the steps below",
     "COPYING": "Copying images from SD card… please wait",
-    "DONE_COPYING": "Copy complete — you can now start the upload (Step 3)",
+    "DONE_COPYING": "Copy complete — now stage the images in Step 3",
+    "STAGING": "Scanning and registering images… please wait",
+    "DONE_STAGING": "Images staged — you can now start the upload (Step 4)",
     "UPLOADING": "Uploading images to the server…",
     "PAUSED": "Upload paused — press Resume to continue",
     "COMPLETE": "All images uploaded successfully!",
 }
+
+
+class _EjectWorker(QThread):
+    """Run SD card eject in a background thread to avoid blocking the UI."""
+
+    done = Signal(bool, str)
+
+    def __init__(self, mount_path: str):
+        super().__init__()
+        self.mount_path = mount_path
+
+    def run(self):
+        success, msg = eject_device(self.mount_path)
+        self.done.emit(success, msg)
+
+
+class _UnstagedCounter(QThread):
+    """Background worker to count unstaged images without blocking the UI."""
+
+    result_ready = Signal(str)
+
+    def __init__(self, staging_dir_text: str, state_manager, parent=None):
+        super().__init__(parent)
+        self._staging_dir_text = staging_dir_text
+        self._state_manager = state_manager
+
+    def run(self):
+        from .staging import IMAGE_EXTENSIONS
+
+        staging_dir = Path(self._staging_dir_text)
+        if not staging_dir.exists():
+            self.result_ready.emit("Folder not found")
+            return
+
+        try:
+            image_paths = []
+            for ext in {e.lower() for e in IMAGE_EXTENSIONS}:
+                if self.isInterruptionRequested():
+                    return
+                pattern = (
+                    f"*{''.join(f'[{c.lower()}{c.upper()}]' if c.isalpha() else c for c in ext)}"
+                )
+                image_paths.extend(staging_dir.rglob(pattern))
+
+            # De-duplicate while preserving order, and ensure we only keep files
+            all_images = [p for p in dict.fromkeys(image_paths) if p.is_file()]
+
+            known_paths = self._state_manager.get_all_staging_paths()
+            unstaged = sum(1 for p in all_images if str(p) not in known_paths)
+
+            total = len(all_images)
+            text = f"{unstaged} un-staged image(s) found ({total} total in folder)"
+        except Exception as e:
+            text = f"Error scanning: {e}"
+
+        self.result_ready.emit(text)
 
 
 def _build_stylesheet(p: dict) -> str:
@@ -286,6 +347,16 @@ def _build_stylesheet(p: dict) -> str:
         font-size: 11pt;
     }}
     QPushButton[objectName="copy_btn"]:hover {{
+        background-color: {p['primary_hover']};
+    }}
+    QPushButton[objectName="stage_btn"] {{
+        background-color: {p['primary']};
+        color: #FFFFFF;
+        border: none;
+        min-height: 38px;
+        font-size: 11pt;
+    }}
+    QPushButton[objectName="stage_btn"]:hover {{
         background-color: {p['primary_hover']};
     }}
     QPushButton[objectName="upload_start_btn"] {{
@@ -488,6 +559,7 @@ class UploaderWindow(QMainWindow):
         self.sd_monitor = SDMonitor()
         self.stats_tracker = StatsTracker()
         self.staging_thread = None
+        self.scan_thread = None
         self.upload_thread = None
 
         # Theme state (default dark)
@@ -562,13 +634,17 @@ class UploaderWindow(QMainWindow):
         step1 = self._create_step1()
         scroll_layout.addWidget(step1)
 
-        # STEP 2 — Copy from SD Card
+        # STEP 2 — Copy from SD Card (Optional)
         step2 = self._create_step2()
         scroll_layout.addWidget(step2)
 
-        # STEP 3 — Upload to Server
-        step3 = self._create_step3()
+        # STEP 3 — Stage Images for Upload
+        step3 = self._create_step3_stage()
         scroll_layout.addWidget(step3)
+
+        # STEP 4 — Upload to Server
+        step4 = self._create_step4()
+        scroll_layout.addWidget(step4)
 
         # Tabs for errors and logs
         self.tabs = QTabWidget()
@@ -629,16 +705,17 @@ class UploaderWindow(QMainWindow):
         group.setLayout(layout)
         return group
 
-    # ---- Step 2: Copy from SD Card ------------------------------------
+    # ---- Step 2: Copy from SD Card (Optional) -------------------------
 
     def _create_step2(self):
-        group = QGroupBox("STEP 2 — Copy from SD Card")
+        group = QGroupBox("STEP 2 — Copy from SD Card (Optional)")
         layout = QVBoxLayout()
         layout.setSpacing(6)
 
         help_label = QLabel(
-            "Insert the SD card from your drone. Wait for it to appear in the list "
-            "below, select it, choose the image type, then press Copy."
+            "Optional — skip this step if images are already in your Local Storage Folder. "
+            "Insert the SD card from your drone, wait for it to appear below, "
+            "then press Copy."
         )
         help_label.setObjectName("help_text")
         help_label.setWordWrap(True)
@@ -659,25 +736,23 @@ class UploaderWindow(QMainWindow):
         list_layout.addWidget(self.sd_refresh_btn)
         layout.addLayout(list_layout)
 
-        # Image type
-        type_layout = QHBoxLayout()
-        type_layout.addWidget(QLabel("Image Type:"))
-        self.image_type_combo = QComboBox()
-        self.image_type_combo.addItems(
-            [
-                "survey",
-                "training_true",
-                "training_false",
-            ]
+        # Checkboxes for post-copy actions
+        checkbox_layout = QHBoxLayout()
+        self.delete_source_checkbox = QCheckBox("Delete images from SD card after copy")
+        self.delete_source_checkbox.setChecked(False)
+        self.delete_source_checkbox.setToolTip(
+            "If checked, images will be removed from the SD card after a verified copy."
         )
-        self.image_type_combo.setToolTip("Choose what kind of flight this SD card is from.")
-        type_layout.addWidget(self.image_type_combo)
-        self.image_type_desc = QLabel("Survey flight images")
-        self.image_type_desc.setObjectName("help_text")
-        type_layout.addWidget(self.image_type_desc)
-        type_layout.addStretch()
-        layout.addLayout(type_layout)
-        self.image_type_combo.currentTextChanged.connect(self._update_image_type_desc)
+        checkbox_layout.addWidget(self.delete_source_checkbox)
+
+        self.eject_sd_checkbox = QCheckBox("Eject SD card when done")
+        self.eject_sd_checkbox.setChecked(False)
+        self.eject_sd_checkbox.setToolTip(
+            "If checked, the SD card will be safely ejected after copying is complete."
+        )
+        checkbox_layout.addWidget(self.eject_sd_checkbox)
+        checkbox_layout.addStretch()
+        layout.addLayout(checkbox_layout)
 
         # Copy button — full width, primary action colour
         self.copy_btn = QPushButton("📋  Copy Images from SD Card")
@@ -703,15 +778,86 @@ class UploaderWindow(QMainWindow):
         group.setLayout(layout)
         return group
 
-    # ---- Step 3: Upload to Server -------------------------------------
+    # ---- Step 3: Stage Images for Upload -------------------------------
 
-    def _create_step3(self):
-        group = QGroupBox("STEP 3 — Upload to Server")
+    def _create_step3_stage(self):
+        group = QGroupBox("STEP 3 — Stage Images for Upload")
         layout = QVBoxLayout()
         layout.setSpacing(6)
 
         help_label = QLabel(
-            "Once images are copied, press Start Upload. You can pause and "
+            "Stage the images in your Local Storage Folder so they can be uploaded. "
+            "Choose the image type, then press Stage. Only un-staged images will be registered."
+        )
+        help_label.setObjectName("help_text")
+        help_label.setWordWrap(True)
+        layout.addWidget(help_label)
+
+        # Un-staged count
+        count_layout = QHBoxLayout()
+        self.unstaged_count_label = QLabel("Scanning…")
+        self.unstaged_count_label.setObjectName("stat_value")
+        count_layout.addWidget(self.unstaged_count_label)
+        self.refresh_unstaged_btn = QPushButton("Refresh Count")
+        self.refresh_unstaged_btn.clicked.connect(self.update_unstaged_count)
+        self.refresh_unstaged_btn.setToolTip("Re-scan the local storage folder for new images.")
+        count_layout.addWidget(self.refresh_unstaged_btn)
+        count_layout.addStretch()
+        layout.addLayout(count_layout)
+
+        # Image type
+        type_layout = QHBoxLayout()
+        type_layout.addWidget(QLabel("Image Type:"))
+        self.image_type_combo = QComboBox()
+        self.image_type_combo.addItems(
+            [
+                "survey",
+                "training_true",
+                "training_false",
+            ]
+        )
+        self.image_type_combo.setToolTip("Choose what kind of flight these images are from.")
+        type_layout.addWidget(self.image_type_combo)
+        self.image_type_desc = QLabel("Survey flight images")
+        self.image_type_desc.setObjectName("help_text")
+        type_layout.addWidget(self.image_type_desc)
+        type_layout.addStretch()
+        layout.addLayout(type_layout)
+        self.image_type_combo.currentTextChanged.connect(self._update_image_type_desc)
+
+        # Stage button — full width, primary action colour
+        self.stage_btn = QPushButton("📂  Stage Images for Upload")
+        self.stage_btn.setObjectName("stage_btn")
+        self.stage_btn.clicked.connect(self.start_folder_scan)
+        self.stage_btn.setToolTip(
+            "Scans your Local Storage Folder and registers un-staged images for upload."
+        )
+        layout.addWidget(self.stage_btn)
+
+        # Progress
+        self.scan_progress = QProgressBar()
+        layout.addWidget(self.scan_progress)
+
+        self.scan_status_label = QLabel()
+        self.scan_status_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        layout.addWidget(self.scan_status_label)
+
+        group.setLayout(layout)
+
+        # Initial count update (deferred so UI is built first)
+        QTimer.singleShot(500, self.update_unstaged_count)
+
+        return group
+
+    # ---- Step 4: Upload to Server -------------------------------------
+
+    def _create_step4(self):
+        group = QGroupBox("STEP 4 — Upload to Server")
+        layout = QVBoxLayout()
+        layout.setSpacing(6)
+
+        help_label = QLabel(
+            "Once images are staged, press Start Upload. You can pause and "
             "resume at any time without losing progress."
         )
         help_label.setObjectName("help_text")
@@ -1105,23 +1251,25 @@ class UploaderWindow(QMainWindow):
             return
 
         sd_card = cards[selected_idx]
-        image_type = self.image_type_combo.currentText()
+        delete_source = self.delete_source_checkbox.isChecked()
 
         msg = (
             f"Ready to copy images?\n\n"
             f"From:  {sd_card.path}\n"
             f"To:  {staging_dir}\n"
-            f"Type:  {image_type}\n"
             f"Images found:  ~{sd_card.count_images()}"
         )
+        if delete_source:
+            msg += "\n\n⚠️  Images will be DELETED from the SD card after copying."
         reply = QMessageBox.question(self, "Confirm Copy", msg, QMessageBox.Yes | QMessageBox.No)
         if reply != QMessageBox.Yes:
             return
 
+        # Remember the SD card path for post-copy eject
+        self._last_sd_card_path = str(sd_card.path)
+
         # Start staging thread
-        self.staging_thread = StagingCopier(
-            sd_card.path, staging_dir, image_type, self.state_manager
-        )
+        self.staging_thread = StagingCopier(sd_card.path, staging_dir, delete_source=delete_source)
         self.staging_thread.progress.connect(self.on_staging_progress)
         self.staging_thread.speed_update.connect(self.on_staging_speed)
         self.staging_thread.finished.connect(self.on_staging_finished)
@@ -1146,24 +1294,53 @@ class UploaderWindow(QMainWindow):
         speed_str = self.stats_tracker.format_rate(bytes_per_sec)
         self.staging_speed_label.setText(speed_str)
 
-    def on_staging_finished(self, successful, failed):
+    def on_staging_finished(self, successful, failed, skipped, aborted):
         """Handle staging completion."""
         self.copy_btn.setEnabled(True)
         self.staging_progress.setValue(0)
         self.staging_status_label.setText("")
         self.staging_speed_label.setText("")
 
-        msg = (
-            f"Copy complete!\n\n"
-            f"Successful:  {successful}\n"
-            f"Failed:  {failed}\n\n"
-            f"You can now start the upload in Step 3."
-        )
-        QMessageBox.information(self, "Copy Complete", msg)
-        self.log(f"Staging completed: {successful} successful, {failed} failed")
+        title = "Copy Stopped" if aborted else "Copy Complete"
+        if aborted:
+            msg = "Copy was stopped early.\n\n"
+        else:
+            msg = "Copy complete!\n\n"
+
+        msg += f"Successfully copied:  {successful}\n" f"Already copied (skipped):  {skipped}\n"
+        if failed:
+            msg += f"Failed to copy:  {failed}\n"
+            title += " (with errors)"
+
+        msg += "\nNow go to Step 3 to stage the images for upload."
+
+        if aborted or failed:
+            QMessageBox.warning(self, title, msg)
+        else:
+            QMessageBox.information(self, title, msg)
+
+        status_word = "stopped" if aborted else "completed"
+        self.log(f"Copy {status_word}: {successful} successful, {skipped} skipped, {failed} failed")
 
         self.set_banner_state("DONE_COPYING")
-        self.update_counts()
+        self.update_unstaged_count()
+
+        # Eject SD card if requested (runs in background thread)
+        if self.eject_sd_checkbox.isChecked() and hasattr(self, "_last_sd_card_path"):
+            self.log("Ejecting SD card…")
+            self._eject_worker = _EjectWorker(self._last_sd_card_path)
+            self._eject_worker.done.connect(self._on_eject_done)
+            self._eject_worker.start()
+
+    def _on_eject_done(self, success, msg):
+        """Handle eject worker completion (runs on UI thread via signal)."""
+        if success:
+            QMessageBox.information(self, "SD Card Ejected", msg)
+            self.log(msg)
+            self.refresh_sd_list()
+        else:
+            QMessageBox.warning(self, "Eject Failed", msg)
+            self.log(f"Eject failed: {msg}")
 
     def on_staging_error(self, filename, error):
         """Handle staging error."""
@@ -1188,6 +1365,90 @@ class UploaderWindow(QMainWindow):
         )
         QMessageBox.critical(self, "Disk Space Critical", msg)
         self.log(f"Critical: Only {gb_remaining:.1f} GB remaining! Stopping copy.")
+
+    # ------------------------------------------------------------------
+    # Folder scan (Stage step)
+    # ------------------------------------------------------------------
+
+    def start_folder_scan(self):
+        """Start scanning the staging folder and registering images."""
+        staging_dir = Path(self.staging_dir_edit.text())
+        if not staging_dir.exists():
+            QMessageBox.warning(
+                self,
+                "Folder Not Found",
+                f"The local storage folder does not exist:\n{staging_dir}\n\n"
+                "Please set it in Step 1.",
+            )
+            return
+
+        image_type = self.image_type_combo.currentText()
+
+        self.scan_thread = FolderScanner(staging_dir, image_type, self.state_manager)
+        self.scan_thread.progress.connect(self.on_scan_progress)
+        self.scan_thread.finished.connect(self.on_scan_finished)
+
+        self.stage_btn.setEnabled(False)
+        self.refresh_unstaged_btn.setEnabled(False)
+        self.scan_progress.setValue(0)
+        self.scan_status_label.setText("")
+        self.scan_thread.start()
+        self.set_banner_state("STAGING")
+        self.log(f"Scanning staging folder for {image_type} images…")
+
+    def on_scan_progress(self, current, total, filename):
+        """Handle folder scan progress update."""
+        self.scan_progress.setMaximum(total)
+        self.scan_progress.setValue(current)
+        self.scan_status_label.setText(f"{current}/{total}: {filename}")
+
+    def on_scan_finished(self, registered, skipped, failed):
+        """Handle folder scan completion."""
+        self.stage_btn.setEnabled(True)
+        self.refresh_unstaged_btn.setEnabled(True)
+        self.scan_progress.setValue(0)
+        self.scan_status_label.setText("")
+
+        msg = (
+            f"Staging complete!\n\n"
+            f"Newly registered:  {registered}\n"
+            f"Already staged:  {skipped}\n"
+        )
+        if failed:
+            msg += f"Failed to register:  {failed}\n"
+        msg += f"\nYou can now start the upload in Step 4."
+
+        if failed:
+            QMessageBox.warning(self, "Staging Complete (with errors)", msg)
+        else:
+            QMessageBox.information(self, "Staging Complete", msg)
+        self.log(f"Staging completed: {registered} registered, {skipped} skipped, {failed} failed")
+
+        self.set_banner_state("DONE_STAGING")
+        self.update_counts()
+        self.update_unstaged_count()
+
+    def update_unstaged_count(self):
+        """Count images in staging dir that are not yet registered in the DB.
+        Runs the potentially expensive scan in a background thread
+        to avoid freezing the UI.
+        """
+        # Avoid launching multiple concurrent scans.
+        worker = getattr(self, "_unstaged_counter_thread", None)
+        if worker is not None and worker.isRunning():
+            return
+
+        self.unstaged_count_label.setText("Scanning staging folder...")
+
+        worker = _UnstagedCounter(
+            self.staging_dir_edit.text(),
+            self.state_manager,
+            self,
+        )
+        self._unstaged_counter_thread = worker
+        worker.result_ready.connect(self.unstaged_count_label.setText)
+        worker.finished.connect(lambda: setattr(self, "_unstaged_counter_thread", None))
+        worker.start()
 
     # ------------------------------------------------------------------
     # Upload
@@ -1217,7 +1478,7 @@ class UploaderWindow(QMainWindow):
             QMessageBox.information(
                 self,
                 "Nothing to Upload",
-                "No images have been copied yet. Complete Step 2 first.",
+                "No images have been staged yet. Complete Step 3 first.",
             )
             return
 
@@ -1410,8 +1671,30 @@ class UploaderWindow(QMainWindow):
             self.staging_thread.stop()
             self.staging_thread.wait()
 
+        if self.scan_thread and self.scan_thread.isRunning():
+            self.scan_thread.stop()
+            self.scan_thread.wait()
+
         if self.upload_thread and self.upload_thread.isRunning():
             self.upload_thread.stop()
             self.upload_thread.wait()
+
+        # Stop async background workers to prevent "Destroyed while thread is still running"
+        if getattr(self, "_eject_worker", None) and self._eject_worker.isRunning():
+            self._eject_worker.requestInterruption()
+            if not self._eject_worker.wait(2000):
+                logger.warning("Eject worker did not stop within 2 seconds; forcing termination")
+                self._eject_worker.terminate()
+                self._eject_worker.wait(1000)
+
+        counter_worker = getattr(self, "_unstaged_counter_thread", None)
+        if counter_worker and counter_worker.isRunning():
+            counter_worker.requestInterruption()
+            if not counter_worker.wait(2000):
+                logger.warning(
+                    "Unstaged counter worker did not stop within 2 seconds; forcing termination"
+                )
+                counter_worker.terminate()
+                counter_worker.wait(1000)
 
         event.accept()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -278,6 +278,10 @@ def app_window(
         window.staging_thread.stop()
         window.staging_thread.wait(5000)
 
+    if window.scan_thread and window.scan_thread.isRunning():
+        window.scan_thread.stop()
+        window.scan_thread.wait(5000)
+
     if window.upload_thread and window.upload_thread.isRunning():
         window.upload_thread.stop()
         window.upload_thread.wait(5000)
@@ -302,6 +306,7 @@ def _make_patched_init(config_path: Path, staging_dir: Path):
         self.sd_monitor = SDMonitor()
         self.stats_tracker = StatsTracker()
         self.staging_thread = None
+        self.scan_thread = None
         self.upload_thread = None
         self._dark_mode = True
 

--- a/tests/integration/test_happy_path.py
+++ b/tests/integration/test_happy_path.py
@@ -1,14 +1,15 @@
 """
-Integration test: Happy path — SD card → copy → upload → all succeed.
+Integration test: Happy path — SD card → copy → stage → upload → all succeed.
 
 Exercises the full user flow:
 1. SD card detected with images
-2. User selects card, chooses image type, clicks "Copy Images from SD Card"
-3. Staging completes successfully
-4. User clicks "Start Upload"
-5. All images pass the check_uploaded pre-flight (not yet uploaded)
-6. All images upload successfully
-7. DB shows all images as "uploaded", staging files are deleted
+2. User selects card, clicks "Copy Images from SD Card"
+3. File copy completes successfully
+4. User clicks "Stage Images for Upload" (registers in DB)
+5. User clicks "Start Upload"
+6. All images pass the check_uploaded pre-flight (not yet uploaded)
+7. All images upload successfully
+8. DB shows all images as "uploaded", staging files are deleted
 """
 
 import pytest
@@ -38,7 +39,7 @@ class TestHappyPathStaging:
         integration_state_manager,
         monkeypatch,
     ):
-        """SD card copy stages all images and records them in the DB."""
+        """SD card copy copies all images to the staging folder (no DB)."""
         window = app_window
 
         monkeypatch.setattr(window.sd_monitor, "get_sd_cards", lambda: [mock_sd_card_info])
@@ -46,7 +47,6 @@ class TestHappyPathStaging:
 
         assert window.sd_list.count() == 1
         window.sd_list.setCurrentRow(0)
-        window.image_type_combo.setCurrentText("survey")
 
         qtbot.mouseClick(window.copy_btn, Qt.MouseButton.LeftButton)
         assert window.staging_thread is not None
@@ -55,13 +55,15 @@ class TestHappyPathStaging:
         wait_for_thread_done(qtbot, lambda: window.staging_thread, timeout=15_000)
         process_events()
 
-        counts = integration_state_manager.get_image_counts()
-        assert counts["staged"] == 5
-
-        staged_files = list(staging_dir.glob("*.jpg")) + list(staging_dir.glob("*.JPG"))
+        # StagingCopier no longer touches DB — verify files copied
+        staged_files = list(staging_dir.rglob("*.jpg")) + list(staging_dir.rglob("*.JPG"))
         assert len(staged_files) == 5
 
-    def test_staging_skips_already_staged(
+        # DB should still be empty (no registration yet)
+        counts = integration_state_manager.get_image_counts()
+        assert counts["staged"] == 0
+
+    def test_staging_skips_already_copied(
         self,
         qtbot,
         app_window,
@@ -78,7 +80,6 @@ class TestHappyPathStaging:
         monkeypatch.setattr(window.sd_monitor, "get_sd_cards", lambda: [mock_sd_card_info])
         window.refresh_sd_list()
         window.sd_list.setCurrentRow(0)
-        window.image_type_combo.setCurrentText("survey")
 
         qtbot.mouseClick(window.copy_btn, Qt.MouseButton.LeftButton)
         assert window.staging_thread is not None
@@ -86,7 +87,34 @@ class TestHappyPathStaging:
         wait_for_thread_done(qtbot, lambda: window.staging_thread, timeout=15_000)
         process_events()
 
-        # Should still be 5 total (duplicates skipped)
+        # Should still be 5 total files (duplicates skipped by file existence check)
+        staged_files = list(staging_dir.glob("*.jpg")) + list(staging_dir.glob("*.JPG"))
+        assert len(staged_files) == 5
+
+
+class TestHappyPathFolderScan:
+    """Test the folder scan (staging → DB registration) step."""
+
+    def test_folder_scan_registers_images(
+        self,
+        qtbot,
+        app_window,
+        staging_dir,
+        integration_state_manager,
+        pre_staged_images,
+    ):
+        """Stage button scans the staging folder and registers images."""
+        window = app_window
+
+        # Set image type and click Stage
+        window.image_type_combo.setCurrentText("survey")
+        qtbot.mouseClick(window.stage_btn, Qt.MouseButton.LeftButton)
+        assert window.scan_thread is not None
+
+        wait_for_thread_done(qtbot, lambda: window.scan_thread, timeout=15_000)
+        process_events()
+
+        # pre_staged_images already adds them to DB, so scan should skip them
         counts = integration_state_manager.get_image_counts()
         assert counts["staged"] == 5
 
@@ -158,9 +186,9 @@ class TestHappyPathUpload:
 
 
 class TestHappyPathEndToEnd:
-    """Full end-to-end: stage from SD card, then upload everything."""
+    """Full end-to-end: copy from SD card, scan/register, then upload."""
 
-    def test_stage_then_upload(
+    def test_copy_stage_upload(
         self,
         qtbot,
         app_window,
@@ -171,17 +199,25 @@ class TestHappyPathEndToEnd:
         integration_state_manager,
         monkeypatch,
     ):
-        """Complete flow: copy images from SD card, then upload them all."""
+        """Complete flow: copy images from SD card, stage them, then upload."""
         window = app_window
 
-        # --- Stage ---
+        # --- Copy from SD ---
         monkeypatch.setattr(window.sd_monitor, "get_sd_cards", lambda: [mock_sd_card_info])
         window.refresh_sd_list()
         window.sd_list.setCurrentRow(0)
-        window.image_type_combo.setCurrentText("survey")
 
         qtbot.mouseClick(window.copy_btn, Qt.MouseButton.LeftButton)
         wait_for_thread_done(qtbot, lambda: window.staging_thread, timeout=15_000)
+        process_events()
+
+        staged_files = list(staging_dir.rglob("*.jpg")) + list(staging_dir.rglob("*.JPG"))
+        assert len(staged_files) == 5
+
+        # --- Stage (register in DB) ---
+        window.image_type_combo.setCurrentText("survey")
+        qtbot.mouseClick(window.stage_btn, Qt.MouseButton.LeftButton)
+        wait_for_thread_done(qtbot, lambda: window.scan_thread, timeout=15_000)
         process_events()
 
         n = integration_state_manager.get_image_counts()["staged"]
@@ -201,3 +237,101 @@ class TestHappyPathEndToEnd:
         assert counts["uploaded"] == n
         assert counts["staged"] == 0
         assert counts["failed"] == 0
+
+
+class TestSkipSdCardFlow:
+    """Test skipping Step 2 entirely — files are already in the staging folder.
+
+    This is the primary use case from Issue #3: the user has manually copied
+    images to the local storage folder and wants to skip the SD card step.
+    """
+
+    def test_skip_sd_card_stage_then_upload(
+        self,
+        qtbot,
+        app_window,
+        upload_key,
+        staging_dir,
+        integration_state_manager,
+    ):
+        """E2E: manually place files in staging, skip Step 2, stage, upload."""
+        window = app_window
+
+        # Simulate user manually copying files to staging dir (skipping Step 2)
+        from tests.integration.conftest import create_test_jpeg
+
+        for i in range(4):
+            create_test_jpeg(staging_dir / f"MANUAL_{i:04d}.jpg")
+
+        # --- Step 3: Stage images (no SD card copy needed) ---
+        window.image_type_combo.setCurrentText("training_true")
+        qtbot.mouseClick(window.stage_btn, Qt.MouseButton.LeftButton)
+        assert window.scan_thread is not None
+
+        wait_for_thread_done(qtbot, lambda: window.scan_thread, timeout=15_000)
+        process_events()
+
+        counts = integration_state_manager.get_image_counts()
+        assert counts["staged"] == 4
+
+        # Verify image type was set correctly
+        staged = integration_state_manager.get_staged_images()
+        assert all(img["image_type"] == "training_true" for img in staged)
+
+        # --- Step 4: Upload ---
+        n = counts["staged"]
+        with aioresponses() as m:
+            for _ in range(n):
+                m.post(CHECK_URL, status=200, body="0")
+                m.post(UPLOAD_URL, status=200, body="SUCCESS")
+
+            qtbot.mouseClick(window.upload_start_btn, Qt.MouseButton.LeftButton)
+            wait_for_thread_done(qtbot, lambda: window.upload_thread, timeout=30_000)
+            process_events()
+
+        counts = integration_state_manager.get_image_counts()
+        assert counts["uploaded"] == 4
+        assert counts["staged"] == 0
+        assert counts["failed"] == 0
+
+    def test_unstaged_count_updates(
+        self,
+        qtbot,
+        app_window,
+        staging_dir,
+        integration_state_manager,
+    ):
+        """update_unstaged_count reflects files not yet in the DB."""
+        window = app_window
+
+        from tests.integration.conftest import create_test_jpeg
+
+        # Add files to staging dir
+        for i in range(3):
+            create_test_jpeg(staging_dir / f"COUNT_{i:04d}.jpg")
+
+        window.update_unstaged_count()
+        wait_for_thread_done(
+            qtbot, lambda: getattr(window, "_unstaged_counter_thread", None), timeout=5_000
+        )
+        process_events()
+
+        text = window.unstaged_count_label.text()
+        assert "3" in text
+        assert "un-staged" in text
+
+        # Stage them
+        window.image_type_combo.setCurrentText("survey")
+        qtbot.mouseClick(window.stage_btn, Qt.MouseButton.LeftButton)
+        wait_for_thread_done(qtbot, lambda: window.scan_thread, timeout=15_000)
+        process_events()
+
+        # Now update count — should show 0 un-staged
+        window.update_unstaged_count()
+        wait_for_thread_done(
+            qtbot, lambda: getattr(window, "_unstaged_counter_thread", None), timeout=5_000
+        )
+        process_events()
+
+        text = window.unstaged_count_label.text()
+        assert "0 un-staged" in text

--- a/tests/integration/test_staging_failures.py
+++ b/tests/integration/test_staging_failures.py
@@ -5,7 +5,7 @@ Covers:
 - Low disk space warning (< 10 GB free)
 - Critical disk space that aborts staging (< 5 GB free)
 - File copy failure (IOError during shutil.copy2)
-- Staging failures are recorded in the database
+- Two-step flow: StagingCopier (pure copy) then FolderScanner (DB registration)
 """
 
 import pytest
@@ -16,7 +16,7 @@ from unittest.mock import patch
 from PySide6.QtCore import Qt
 
 from src.state_manager import StateManager
-from src.staging import StagingCopier
+from src.staging import StagingCopier, FolderScanner
 
 from .conftest import create_test_jpeg, wait_for_thread_done, process_events
 
@@ -51,7 +51,6 @@ class TestDiskSpaceWarning:
         monkeypatch.setattr(window.sd_monitor, "get_sd_cards", lambda: [mock_sd_card_info])
         window.refresh_sd_list()
         window.sd_list.setCurrentRow(0)
-        window.image_type_combo.setCurrentText("survey")
 
         fake_usage = _DiskUsage(
             total=500 * 1024**3,
@@ -73,8 +72,9 @@ class TestDiskSpaceWarning:
         assert len(warnings_received) > 0
         assert all(w < 10.0 for w in warnings_received)
 
-        counts = integration_state_manager.get_image_counts()
-        assert counts["staged"] > 0
+        # StagingCopier no longer registers in DB — verify files were copied
+        copied = list(staging_dir.rglob("*.jpg")) + list(staging_dir.rglob("*.JPG"))
+        assert len(copied) > 0
 
     def test_critical_disk_space_aborts_staging(
         self,
@@ -92,7 +92,6 @@ class TestDiskSpaceWarning:
         monkeypatch.setattr(window.sd_monitor, "get_sd_cards", lambda: [mock_sd_card_info])
         window.refresh_sd_list()
         window.sd_list.setCurrentRow(0)
-        window.image_type_combo.setCurrentText("survey")
 
         fake_usage = _DiskUsage(
             total=500 * 1024**3,
@@ -113,14 +112,15 @@ class TestDiskSpaceWarning:
 
         assert len(critical_received) > 0
 
-        counts = integration_state_manager.get_image_counts()
-        assert counts["staged"] <= 1
+        # At most 1 file copied before abort
+        copied = list(staging_dir.rglob("*.jpg")) + list(staging_dir.rglob("*.JPG"))
+        assert len(copied) <= 1
 
 
 class TestCopyFailures:
     """Tests for file copy errors during staging."""
 
-    def test_copy_failure_records_staging_failure(
+    def test_copy_failure_emits_errors(
         self,
         qtbot,
         app_window,
@@ -130,13 +130,12 @@ class TestCopyFailures:
         integration_state_manager,
         monkeypatch,
     ):
-        """When shutil.copy2 raises IOError, the failure is recorded in the DB."""
+        """When shutil.copy2 raises IOError, error signals are emitted."""
         window = app_window
 
         monkeypatch.setattr(window.sd_monitor, "get_sd_cards", lambda: [mock_sd_card_info])
         window.refresh_sd_list()
         window.sd_list.setCurrentRow(0)
-        window.image_type_combo.setCurrentText("survey")
 
         def failing_copy2(src, dst, **kwargs):
             raise IOError("Simulated disk error")
@@ -154,11 +153,9 @@ class TestCopyFailures:
 
         assert len(errors_received) == 5
 
-        failures = integration_state_manager.get_staging_failures()
-        assert len(failures) == 5
-
-        counts = integration_state_manager.get_image_counts()
-        assert counts["staged"] == 0
+        # No files in staging since all copies failed
+        copied = list(staging_dir.rglob("*.jpg")) + list(staging_dir.rglob("*.JPG"))
+        assert len(copied) == 0
 
     def test_partial_copy_failure(
         self,
@@ -176,7 +173,6 @@ class TestCopyFailures:
         monkeypatch.setattr(window.sd_monitor, "get_sd_cards", lambda: [mock_sd_card_info])
         window.refresh_sd_list()
         window.sd_list.setCurrentRow(0)
-        window.image_type_combo.setCurrentText("survey")
 
         import shutil
 
@@ -195,11 +191,9 @@ class TestCopyFailures:
         wait_for_thread_done(qtbot, lambda: window.staging_thread, timeout=15_000)
         process_events()
 
-        counts = integration_state_manager.get_image_counts()
-        assert counts["staged"] == 3
-
-        failures = integration_state_manager.get_staging_failures()
-        assert len(failures) == 2
+        # 3 of 5 files should have been copied successfully
+        copied = list(staging_dir.rglob("*.jpg")) + list(staging_dir.rglob("*.JPG"))
+        assert len(copied) == 3
 
 
 class TestStagingDirectly:
@@ -212,10 +206,66 @@ class TestStagingDirectly:
         staging = tmp_path / "staging_empty"
         staging.mkdir()
 
-        copier = StagingCopier(empty_sd, staging, "survey", integration_state_manager)
+        copier = StagingCopier(empty_sd, staging)
 
         copier.start()
         wait_for_thread_done(qtbot, lambda: copier, timeout=10_000)
 
+        # No files should be copied
+        copied = list(staging.glob("*.jpg"))
+        assert len(copied) == 0
+
+
+class TestFolderScannerIntegration:
+    """Integration tests for the FolderScanner (DB registration step)."""
+
+    def test_copy_then_scan_e2e(self, qtbot, tmp_path, integration_state_manager):
+        """End-to-end: StagingCopier copies files, FolderScanner registers them."""
+        sd = tmp_path / "sd_card"
+        sd.mkdir()
+        staging = tmp_path / "staging_out"
+        staging.mkdir()
+
+        # Create test images on "SD card"
+        for i in range(3):
+            create_test_jpeg(sd / f"IMG_{i:04d}.jpg")
+
+        # Step 1: Copy
+        copier = StagingCopier(sd, staging)
+        copier.start()
+        wait_for_thread_done(qtbot, lambda: copier, timeout=10_000)
+
+        copied = list(staging.glob("*.jpg"))
+        assert len(copied) == 3
+
+        # Step 2: Scan and register
+        scanner = FolderScanner(staging, "survey", integration_state_manager)
+        scanner.start()
+        wait_for_thread_done(qtbot, lambda: scanner, timeout=10_000)
+
         counts = integration_state_manager.get_image_counts()
-        assert counts["staged"] == 0
+        assert counts["staged"] == 3
+
+    def test_scan_skips_already_registered(self, qtbot, tmp_path, integration_state_manager):
+        """FolderScanner skips images already in the DB."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+
+        # Create and pre-register one image
+        img_path = staging / "IMG_0000.jpg"
+        create_test_jpeg(img_path)
+        integration_state_manager.add_image(
+            filename="IMG_0000.jpg",
+            staging_path=str(img_path),
+            image_type="survey",
+        )
+
+        # Create another un-registered
+        create_test_jpeg(staging / "IMG_0001.jpg")
+
+        scanner = FolderScanner(staging, "survey", integration_state_manager)
+        scanner.start()
+        wait_for_thread_done(qtbot, lambda: scanner, timeout=10_000)
+
+        counts = integration_state_manager.get_image_counts()
+        assert counts["staged"] == 2  # 1 pre-registered + 1 newly scanned

--- a/tests/test_sd_eject.py
+++ b/tests/test_sd_eject.py
@@ -1,0 +1,170 @@
+"""Unit tests for SD card eject functionality."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+import subprocess
+from src.sd_monitor import eject_device, _device_for_mount
+
+
+class TestEjectDeviceLinux:
+    """Test eject_device on Linux (udisksctl / umount fallback)."""
+
+    @patch("src.sd_monitor.sys")
+    @patch("src.sd_monitor._device_for_mount", return_value="/dev/sdb1")
+    @patch("src.sd_monitor.subprocess.run")
+    def test_eject_linux_udisksctl_success(self, mock_run, mock_dev, mock_sys):
+        """udisksctl unmount + power-off succeeds."""
+        mock_sys.platform = "linux"
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        success, msg = eject_device("/media/user/SDCARD")
+
+        assert success is True
+        assert "safely remove" in msg.lower()
+        # Should have been called twice: unmount then power-off
+        assert mock_run.call_count == 2
+
+    @patch("src.sd_monitor.sys")
+    @patch("src.sd_monitor._device_for_mount", return_value="/dev/sdb1")
+    @patch("src.sd_monitor.subprocess.run")
+    def test_eject_linux_udisksctl_fails_umount_fallback(self, mock_run, mock_dev, mock_sys):
+        """When udisksctl fails, falls back to umount."""
+        mock_sys.platform = "linux"
+        results = [
+            MagicMock(returncode=1, stderr="udisksctl failed"),  # udisksctl fails
+            MagicMock(returncode=0, stderr=""),  # umount succeeds
+        ]
+        mock_run.side_effect = results
+
+        success, msg = eject_device("/media/user/SDCARD")
+
+        assert success is True
+        assert "unmounted" in msg.lower()
+
+    @patch("src.sd_monitor.sys")
+    @patch("src.sd_monitor._device_for_mount", return_value="/dev/sdb1")
+    @patch("src.sd_monitor.subprocess.run")
+    def test_eject_linux_both_fail(self, mock_run, mock_dev, mock_sys):
+        """When both udisksctl and umount fail, returns error."""
+        mock_sys.platform = "linux"
+        mock_run.return_value = MagicMock(returncode=1, stderr="device busy")
+
+        success, msg = eject_device("/media/user/SDCARD")
+
+        assert success is False
+        assert "device busy" in msg.lower()
+
+    @patch("src.sd_monitor.sys")
+    @patch("src.sd_monitor._device_for_mount", return_value="/dev/sdb1")
+    @patch("src.sd_monitor.subprocess.run")
+    def test_eject_linux_unmount_ok_poweroff_fails(self, mock_run, mock_dev, mock_sys):
+        """When unmount succeeds but power-off fails, returns failure with warning."""
+        mock_sys.platform = "linux"
+        results = [
+            MagicMock(returncode=0, stderr=""),  # unmount succeeds
+            MagicMock(returncode=1, stderr="Authorization required"),  # power-off fails
+        ]
+        mock_run.side_effect = results
+
+        success, msg = eject_device("/media/user/SDCARD")
+
+        assert success is False
+        assert "unmounted" in msg.lower()
+        assert "powering off" in msg.lower()
+
+
+class TestEjectDeviceMacOS:
+    """Test eject_device on macOS."""
+
+    @patch("src.sd_monitor.sys")
+    @patch("src.sd_monitor.subprocess.run")
+    def test_eject_macos_success(self, mock_run, mock_sys):
+        mock_sys.platform = "darwin"
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        success, msg = eject_device("/Volumes/SDCARD")
+
+        assert success is True
+        assert "safely remove" in msg.lower()
+
+    @patch("src.sd_monitor.sys")
+    @patch("src.sd_monitor.subprocess.run")
+    def test_eject_macos_failure(self, mock_run, mock_sys):
+        mock_sys.platform = "darwin"
+        mock_run.return_value = MagicMock(returncode=1, stderr="disk in use")
+
+        success, msg = eject_device("/Volumes/SDCARD")
+
+        assert success is False
+        assert "disk in use" in msg.lower()
+
+
+class TestEjectDeviceWindows:
+    """Test eject_device on Windows."""
+
+    @patch("src.sd_monitor.sys")
+    @patch("src.sd_monitor.subprocess.run")
+    def test_eject_windows_success(self, mock_run, mock_sys):
+        mock_sys.platform = "win32"
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        success, msg = eject_device("E:\\")
+
+        assert success is True
+        assert "safely remove" in msg.lower()
+
+
+class TestEjectDeviceEdgeCases:
+    """Test eject_device edge cases."""
+
+    @patch("src.sd_monitor.sys")
+    @patch("src.sd_monitor.subprocess.run", side_effect=FileNotFoundError("udisksctl"))
+    def test_eject_tool_not_found(self, mock_run, mock_sys):
+        mock_sys.platform = "linux"
+
+        success, msg = eject_device("/media/user/SDCARD")
+
+        assert success is False
+        assert "not found" in msg.lower()
+
+    @patch("src.sd_monitor.sys")
+    @patch("src.sd_monitor.subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 30))
+    def test_eject_timeout(self, mock_run, mock_sys):
+        mock_sys.platform = "linux"
+
+        success, msg = eject_device("/media/user/SDCARD")
+
+        assert success is False
+        assert "timed out" in msg.lower()
+
+    @patch("src.sd_monitor.sys")
+    def test_eject_unsupported_platform(self, mock_sys):
+        mock_sys.platform = "freebsd"
+
+        success, msg = eject_device("/mnt/sd")
+
+        assert success is False
+        assert "not supported" in msg.lower()
+
+
+class TestDeviceForMount:
+    """Test the _device_for_mount helper."""
+
+    @patch("src.sd_monitor.psutil.disk_partitions")
+    def test_finds_device_for_known_mount(self, mock_parts):
+        mock_parts.return_value = [
+            MagicMock(mountpoint="/media/user/SDCARD", device="/dev/sdb1"),
+            MagicMock(mountpoint="/", device="/dev/sda1"),
+        ]
+
+        result = _device_for_mount("/media/user/SDCARD")
+        assert result == "/dev/sdb1"
+
+    @patch("src.sd_monitor.psutil.disk_partitions")
+    def test_returns_mount_if_not_found(self, mock_parts):
+        mock_parts.return_value = [
+            MagicMock(mountpoint="/", device="/dev/sda1"),
+        ]
+
+        result = _device_for_mount("/media/user/UNKNOWN")
+        assert result == "/media/user/UNKNOWN"

--- a/tests/test_staging_helpers.py
+++ b/tests/test_staging_helpers.py
@@ -1,4 +1,4 @@
-"""Unit tests for StagingCopier helper methods (no QThread required)."""
+"""Unit tests for StagingCopier and FolderScanner helper methods (no QThread required)."""
 
 import shutil
 import time
@@ -6,22 +6,20 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 from PIL import Image
-from src.staging import StagingCopier
+from src.staging import StagingCopier, FolderScanner, _extract_exif_timestamp
 from src.state_manager import StateManager
 
 
 @pytest.fixture()
-def copier(tmp_path, mock_state_manager):
+def copier(tmp_path):
     """A StagingCopier instance ready for direct method calls (no thread started)."""
     sd_path = tmp_path / "sd"
     staging = tmp_path / "staging"
     sd_path.mkdir()
     staging.mkdir()
     c = StagingCopier(
-        sd_card_path=sd_path,
+        source_path=sd_path,
         staging_dir=staging,
-        image_type="survey",
-        state_manager=mock_state_manager,
     )
     # Zero out all retry delays so tests are fast
     c.RETRY_DELAYS = [0.0, 0.0, 0.0]
@@ -78,6 +76,12 @@ class TestExtractExifTimestamp:
         result = copier._extract_exif_timestamp(missing)
         # File doesn't exist — can't read mtime either
         assert result is None
+
+    def test_module_level_function_works(self, jpeg_with_exif):
+        """The standalone _extract_exif_timestamp function works."""
+        result = _extract_exif_timestamp(jpeg_with_exif)
+        assert result is not None
+        assert result.startswith("2024-07-15T08:30:00")
 
 
 # ---------------------------------------------------------------------------
@@ -149,3 +153,347 @@ class TestCopyFileWithRetry:
             result = copier._copy_file_with_retry(src, dst)
 
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# StagingCopier — no DB interaction
+# ---------------------------------------------------------------------------
+
+
+class TestStagingCopierNoDb:
+    def test_copier_has_no_state_manager(self, copier):
+        """StagingCopier should not have a state_manager attribute."""
+        assert not hasattr(copier, "state_manager")
+
+    def test_copier_has_delete_source_flag(self, tmp_path):
+        """StagingCopier accepts a delete_source flag."""
+        c = StagingCopier(
+            source_path=tmp_path / "sd",
+            staging_dir=tmp_path / "staging",
+            delete_source=True,
+        )
+        assert c.delete_source is True
+
+    def test_copier_default_no_delete(self, copier):
+        """delete_source defaults to False."""
+        assert copier.delete_source is False
+
+    def test_run_copies_files_without_db(self, tmp_path):
+        """StagingCopier.run() copies files without any DB interaction."""
+        sd = tmp_path / "sd"
+        staging = tmp_path / "staging"
+        sd.mkdir()
+        staging.mkdir()
+
+        # Create test images on "SD card"
+        for i in range(3):
+            img = Image.new("RGB", (10, 10), color="red")
+            img.save(sd / f"IMG_{i:04d}.jpg", "JPEG")
+
+        c = StagingCopier(sd, staging)
+        c.RETRY_DELAYS = [0.0, 0.0, 0.0]
+        c.run()  # Run synchronously
+
+        # Files should be in staging
+        copied = list(staging.glob("*.jpg"))
+        assert len(copied) == 3
+
+        # Source files should still exist (delete_source=False)
+        originals = list(sd.glob("*.jpg"))
+        assert len(originals) == 3
+
+    def test_run_deletes_source_when_flag_set(self, tmp_path):
+        """StagingCopier.run() with delete_source=True removes originals after copy."""
+        sd = tmp_path / "sd"
+        staging = tmp_path / "staging"
+        sd.mkdir()
+        staging.mkdir()
+
+        for i in range(3):
+            img = Image.new("RGB", (10, 10), color="blue")
+            img.save(sd / f"IMG_{i:04d}.jpg", "JPEG")
+
+        c = StagingCopier(sd, staging, delete_source=True)
+        c.RETRY_DELAYS = [0.0, 0.0, 0.0]
+        c.run()  # Run synchronously
+
+        # Files should be in staging
+        copied = list(staging.glob("*.jpg"))
+        assert len(copied) == 3
+
+        # Source files should be DELETED
+        originals = list(sd.glob("*.jpg"))
+        assert len(originals) == 0
+
+    def test_run_tracks_copied_files_list(self, tmp_path):
+        """StagingCopier.copied_files tracks all successfully copied files."""
+        sd = tmp_path / "sd"
+        staging = tmp_path / "staging"
+        sd.mkdir()
+        staging.mkdir()
+
+        for i in range(2):
+            img = Image.new("RGB", (10, 10), color="green")
+            img.save(sd / f"IMG_{i:04d}.jpg", "JPEG")
+
+        c = StagingCopier(sd, staging)
+        c.RETRY_DELAYS = [0.0, 0.0, 0.0]
+        c.run()
+
+        assert len(c.copied_files) == 2
+        assert all(p.parent == staging for p in c.copied_files)
+
+    def test_run_preserves_relative_directory_structure(self, tmp_path):
+        """StagingCopier.run() preserves relative directory paths from the source."""
+        sd = tmp_path / "sd"
+        staging = tmp_path / "staging"
+        sd.mkdir()
+        staging.mkdir()
+
+        # Create two files with the same name in different subdirectories
+        dir1 = sd / "DCIM" / "100"
+        dir2 = sd / "DCIM" / "101"
+        dir1.mkdir(parents=True)
+        dir2.mkdir(parents=True)
+
+        img = Image.new("RGB", (10, 10), color="red")
+        img.save(dir1 / "IMG_0000.jpg", "JPEG")
+        img.save(dir2 / "IMG_0000.jpg", "JPEG")
+
+        c = StagingCopier(sd, staging)
+        c.RETRY_DELAYS = [0.0, 0.0, 0.0]
+        c.run()
+
+        assert len(c.copied_files) == 2
+        # Verify the structure is preserved
+        assert (staging / "DCIM" / "100" / "IMG_0000.jpg").exists()
+        assert (staging / "DCIM" / "101" / "IMG_0000.jpg").exists()
+
+    def test_run_skips_files_already_in_staging(self, tmp_path):
+        """StagingCopier.run() skips files that already exist in staging dir."""
+        sd = tmp_path / "sd"
+        staging = tmp_path / "staging"
+        sd.mkdir()
+        staging.mkdir()
+
+        # Create image on SD and a copy already in staging
+        img = Image.new("RGB", (10, 10), color="red")
+        img.save(sd / "IMG_0000.jpg", "JPEG")
+        img.save(staging / "IMG_0000.jpg", "JPEG")  # Already exists
+
+        c = StagingCopier(sd, staging)
+        c.RETRY_DELAYS = [0.0, 0.0, 0.0]
+        c.run()
+
+        # Should not be in copied_files since it was skipped
+        assert len(c.copied_files) == 0
+
+    def test_run_skips_files_already_in_staging_emits_skipped(self, tmp_path):
+        """StagingCopier.finished emits skipped=1 when a destination file exists."""
+        sd = tmp_path / "sd"
+        staging = tmp_path / "staging"
+        sd.mkdir()
+        staging.mkdir()
+
+        img = Image.new("RGB", (10, 10), color="red")
+        img.save(sd / "IMG_0000.jpg", "JPEG")
+        img.save(staging / "IMG_0000.jpg", "JPEG")  # Already exists
+
+        c = StagingCopier(sd, staging)
+        c.RETRY_DELAYS = [0.0, 0.0, 0.0]
+
+        mock_finished = MagicMock()
+        c.finished.connect(mock_finished)
+        c.run()
+
+        # Emit signature: successful, failed, skipped, aborted
+        mock_finished.assert_called_once_with(0, 0, 1, False)
+        # Source should still exist since delete_source=False by default
+        assert (sd / "IMG_0000.jpg").exists()
+
+    def test_run_deletes_skipped_source_on_size_match(self, tmp_path):
+        """StagingCopier.run() deletes source for skipped files if sizes match and delete_source is True."""
+        sd = tmp_path / "sd"
+        staging = tmp_path / "staging"
+        sd.mkdir()
+        staging.mkdir()
+
+        img_data = b"identical_content"
+        src_file = sd / "IMG_0000.jpg"
+        dst_file = staging / "IMG_0000.jpg"
+
+        with open(src_file, "wb") as f:
+            f.write(img_data)
+        with open(dst_file, "wb") as f:
+            f.write(img_data)
+
+        c = StagingCopier(sd, staging, delete_source=True)
+        c.run()
+
+        # Should be skipped because it exists
+        # But since delete_source=True and size matches, source should be deleted
+        assert not src_file.exists()
+        assert dst_file.exists()
+
+    def test_run_does_not_delete_skipped_source_on_size_mismatch(self, tmp_path):
+        """StagingCopier.run() preserves source for skipped files if sizes differ."""
+        sd = tmp_path / "sd"
+        staging = tmp_path / "staging"
+        sd.mkdir()
+        staging.mkdir()
+
+        src_file = sd / "IMG_0000.jpg"
+        dst_file = staging / "IMG_0000.jpg"
+
+        with open(src_file, "wb") as f:
+            f.write(b"content_a")
+        with open(dst_file, "wb") as f:
+            f.write(b"different_content_b")
+
+        c = StagingCopier(sd, staging, delete_source=True)
+        c.run()
+
+        # Should be skipped, and since sizes differ, source must be preserved
+        assert src_file.exists()
+        assert dst_file.exists()
+
+    def test_run_case_insensitive_deduplication(self, tmp_path):
+        """StagingCopier.run() filters by suffix.lower() to prevent duplicates."""
+        sd = tmp_path / "sd"
+        staging = tmp_path / "staging"
+        sd.mkdir()
+        staging.mkdir()
+
+        # Save an image with uppercase extension
+        img = Image.new("RGB", (10, 10), color="blue")
+        img.save(sd / "LOWER.jpg", "JPEG")
+        img.save(sd / "UPPER.JPG", "JPEG")
+        img.save(sd / "MIXED.JpG", "JPEG")
+
+        c = StagingCopier(sd, staging)
+        c.RETRY_DELAYS = [0.0, 0.0, 0.0]
+
+        mock_finished = MagicMock()
+        c.finished.connect(mock_finished)
+        c.run()
+
+        # Should match all 3, but exactly 3, not 3 per extension variant
+        mock_finished.assert_called_once_with(3, 0, 0, False)
+        assert len(c.copied_files) == 3
+
+
+# ---------------------------------------------------------------------------
+# FolderScanner
+# ---------------------------------------------------------------------------
+
+
+class TestFolderScanner:
+    def test_scans_and_registers_images(self, tmp_path, mock_state_manager):
+        """FolderScanner registers un-tracked images in the DB."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        for i in range(3):
+            img = Image.new("RGB", (10, 10), color="red")
+            img.save(staging / f"IMG_{i:04d}.jpg", "JPEG")
+
+        scanner = FolderScanner(staging, "survey", mock_state_manager)
+        # Run synchronously (not as a thread)
+        scanner.run()
+
+        # All 3 should be registered
+        counts = mock_state_manager.get_image_counts()
+        assert counts["staged"] == 3
+
+    def test_skips_already_registered(self, tmp_path, mock_state_manager):
+        """FolderScanner skips images already in the DB."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+
+        # Create and pre-register one image
+        img = Image.new("RGB", (10, 10), color="blue")
+        img_path = staging / "IMG_0000.jpg"
+        img.save(img_path, "JPEG")
+        mock_state_manager.add_image(
+            filename="IMG_0000.jpg",
+            staging_path=str(img_path),
+            image_type="survey",
+            file_size=img_path.stat().st_size,
+        )
+
+        # Create a second un-registered image
+        img2 = Image.new("RGB", (10, 10), color="green")
+        img2.save(staging / "IMG_0001.jpg", "JPEG")
+
+        scanner = FolderScanner(staging, "survey", mock_state_manager)
+        scanner.run()
+
+        # Should have 2 total (1 pre-registered + 1 newly registered)
+        counts = mock_state_manager.get_image_counts()
+        assert counts["staged"] == 2
+
+    def test_empty_folder(self, tmp_path, mock_state_manager):
+        """FolderScanner handles an empty folder."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+
+        scanner = FolderScanner(staging, "survey", mock_state_manager)
+        scanner.run()
+
+        counts = mock_state_manager.get_image_counts()
+        assert counts["staged"] == 0
+
+    def test_uses_correct_image_type(self, tmp_path, mock_state_manager):
+        """FolderScanner registers images with the specified image type."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        img = Image.new("RGB", (10, 10), color="red")
+        img.save(staging / "IMG_0000.jpg", "JPEG")
+
+        scanner = FolderScanner(staging, "training_true", mock_state_manager)
+        scanner.run()
+
+        images = mock_state_manager.get_staged_images()
+        assert len(images) == 1
+        assert images[0]["image_type"] == "training_true"
+
+    def test_emits_failed_when_registration_fails(self, tmp_path, mock_state_manager):
+        """FolderScanner emissions failed=1 when add_image raises."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        img = Image.new("RGB", (10, 10), color="red")
+        img.save(staging / "IMG_0000.jpg", "JPEG")
+
+        scanner = FolderScanner(staging, "survey", mock_state_manager)
+
+        # force registration to fail
+        def blow_up(*args, **kwargs):
+            raise ValueError("DB down")
+
+        mock_state_manager.add_image = blow_up
+
+        mock_finished = MagicMock()
+        scanner.finished.connect(mock_finished)
+        scanner.run()
+
+        # registered=0, skipped=0, failed=1
+        mock_finished.assert_called_once_with(0, 0, 1)
+
+    def test_folder_scanner_case_insensitive_deduplication(self, tmp_path, mock_state_manager):
+        """FolderScanner filters by lowercase suffix to prevent duplicate DB writes."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+
+        # Save an image with uppercase extension
+        img = Image.new("RGB", (10, 10), color="blue")
+        img.save(staging / "LOWER.jpg", "JPEG")
+        img.save(staging / "UPPER.JPG", "JPEG")
+        img.save(staging / "MIXED.JpG", "JPEG")
+
+        scanner = FolderScanner(staging, "survey", mock_state_manager)
+
+        mock_finished = MagicMock()
+        scanner.finished.connect(mock_finished)
+        scanner.run()
+
+        # registered=3, skipped=0, failed=0
+        mock_finished.assert_called_once_with(3, 0, 0)

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -195,3 +195,35 @@ def test_reset_stuck_uploading_returns_zero_when_none(mock_state_manager):
     """reset_stuck_uploading returns 0 when no images are stuck."""
     mock_state_manager.add_image("fine.jpg", "/tmp/fine.jpg", "survey")
     assert mock_state_manager.reset_stuck_uploading() == 0
+
+
+def test_image_exists_by_path_returns_true(mock_state_manager):
+    """image_exists_by_path returns True for a known staging path."""
+    mock_state_manager.add_image("exists.jpg", "/tmp/staging/exists.jpg", "survey")
+
+    assert mock_state_manager.image_exists_by_path("/tmp/staging/exists.jpg") is True
+
+
+def test_image_exists_by_path_returns_false(mock_state_manager):
+    """image_exists_by_path returns False for an unknown staging path."""
+    assert mock_state_manager.image_exists_by_path("/tmp/staging/ghost.jpg") is False
+
+
+def test_image_exists_by_path_any_status(mock_state_manager):
+    """image_exists_by_path returns True regardless of image status."""
+    image_id = mock_state_manager.add_image("up.jpg", "/tmp/staging/up.jpg", "survey")
+    mock_state_manager.update_image_status(image_id, "uploaded")
+
+    assert mock_state_manager.image_exists_by_path("/tmp/staging/up.jpg") is True
+
+
+def test_get_all_staging_paths(mock_state_manager):
+    """get_all_staging_paths returns a set of all known staging paths."""
+    mock_state_manager.add_image("a.jpg", "/tmp/staging/a.jpg", "survey")
+    mock_state_manager.add_image("b.jpg", "/tmp/staging/b.jpg", "survey")
+
+    paths = mock_state_manager.get_all_staging_paths()
+    assert isinstance(paths, set)
+    assert "/tmp/staging/a.jpg" in paths
+    assert "/tmp/staging/b.jpg" in paths
+    assert "/tmp/staging/unknown.jpg" not in paths

--- a/tests/test_uploader_ui.py
+++ b/tests/test_uploader_ui.py
@@ -6,6 +6,8 @@ Covers:
 - Theme toggling and config persistence
 - Advanced settings panel collapse/expand
 - Staging speed label wiring
+- 4-step wizard layout
+- Stage step UI elements
 """
 
 import json
@@ -42,6 +44,7 @@ def _make_patched_init(config_path: Path, staging_dir: Path):
         self.sd_monitor = SDMonitor()
         self.stats_tracker = StatsTracker()
         self.staging_thread = None
+        self.scan_thread = None
         self.upload_thread = None
         self._dark_mode = True
 
@@ -162,6 +165,14 @@ class TestBannerState:
             texts.add(ui_window.status_banner.text())
         assert len(texts) == len(_BANNER_TEXT)
 
+    def test_staging_banner_state(self, ui_window):
+        """The STAGING and DONE_STAGING banner states exist and produce correct text."""
+        ui_window.set_banner_state("STAGING")
+        assert "registering" in ui_window.status_banner.text().lower()
+
+        ui_window.set_banner_state("DONE_STAGING")
+        assert "staged" in ui_window.status_banner.text().lower()
+
 
 # ---------------------------------------------------------------------------
 # Theme toggle tests
@@ -249,3 +260,102 @@ class TestStagingSpeedLabel:
         ui_window.on_staging_speed(52_428_800)  # 50 MB/s
         text = ui_window.staging_speed_label.text()
         assert "MB/s" in text
+
+
+# ---------------------------------------------------------------------------
+# 4-step wizard layout tests
+# ---------------------------------------------------------------------------
+
+
+class TestWizardLayout:
+    """Test that the 4-step wizard is correctly laid out."""
+
+    def test_step2_optional_label(self, ui_window):
+        """Step 2 title contains 'Optional'."""
+        assert hasattr(ui_window, "copy_btn")
+        assert hasattr(ui_window, "sd_list")
+
+    def test_step3_stage_exists(self, ui_window):
+        """Step 3 (Stage) has the stage button and image type combo."""
+        assert hasattr(ui_window, "stage_btn")
+        assert hasattr(ui_window, "image_type_combo")
+        assert hasattr(ui_window, "unstaged_count_label")
+        assert hasattr(ui_window, "scan_progress")
+
+    def test_step4_upload_exists(self, ui_window):
+        """Step 4 (Upload) has the upload start button."""
+        assert hasattr(ui_window, "upload_start_btn")
+        assert hasattr(ui_window, "upload_pause_btn")
+        assert hasattr(ui_window, "upload_stop_btn")
+
+    def test_sd_card_checkboxes_exist(self, ui_window):
+        """Step 2 has the delete and eject checkboxes."""
+        assert hasattr(ui_window, "delete_source_checkbox")
+        assert hasattr(ui_window, "eject_sd_checkbox")
+        assert ui_window.delete_source_checkbox.isChecked() is False
+        assert ui_window.eject_sd_checkbox.isChecked() is False
+
+    def test_scan_thread_attribute_exists(self, ui_window):
+        """scan_thread attribute is initialized to None."""
+        assert hasattr(ui_window, "scan_thread")
+        assert ui_window.scan_thread is None
+
+    def test_folder_scan_disables_refresh_btn(self, ui_window, qtbot):
+        """The refresh_unstaged_btn is disabled during a folder scan to prevent DB lockup."""
+        # Initial state: button should be enabled
+        assert ui_window.refresh_unstaged_btn.isEnabled()
+
+        # Mock the folder scanner so it doesn't actually run real FS/DB work
+        from unittest.mock import MagicMock
+
+        mock_thread = MagicMock()
+        ui_window.scan_thread = mock_thread
+
+        # Simulate starting a scan manually to isolate the UI toggle logic
+        ui_window.stage_btn.setEnabled(False)
+        ui_window.refresh_unstaged_btn.setEnabled(False)
+
+        assert not ui_window.refresh_unstaged_btn.isEnabled()
+
+        # Simulate finishing the scan
+        ui_window.on_scan_finished(10, 0, 0)
+
+        # Button should be re-enabled
+        assert ui_window.refresh_unstaged_btn.isEnabled()
+
+    def test_eject_worker_triggered(self, ui_window, monkeypatch):
+        """Verify the background _EjectWorker is launched when eject is requested."""
+        ui_window.eject_sd_checkbox.setChecked(True)
+        ui_window._last_sd_card_path = "/dev/sdd1"
+
+        # Mock the eject worker so we don't actually eject anything
+        from src.uploader import _EjectWorker
+
+        mock_start = MagicMock()
+        monkeypatch.setattr(_EjectWorker, "start", mock_start)
+
+        ui_window.on_staging_finished(10, 0, 0, False)
+
+        assert mock_start.called
+        assert isinstance(ui_window._eject_worker, _EjectWorker)
+        assert ui_window._eject_worker.mount_path == "/dev/sdd1"
+
+    def test_on_eject_done_updates_ui(self, ui_window, monkeypatch):
+        """Verify _on_eject_done correctly shows success/warning dialogs."""
+        mock_info = MagicMock()
+        mock_warning = MagicMock()
+        monkeypatch.setattr("src.uploader.QMessageBox.information", mock_info)
+        monkeypatch.setattr("src.uploader.QMessageBox.warning", mock_warning)
+
+        # Mock refresh_sd_list since it relies on finding actual devices
+        monkeypatch.setattr(ui_window, "refresh_sd_list", MagicMock())
+
+        # Success case
+        ui_window._on_eject_done(True, "Ejected successfully")
+        mock_info.assert_called_once()
+        assert "Ejected successfully" in mock_info.call_args[0][2]
+
+        # Failure case
+        ui_window._on_eject_done(False, "Device is busy")
+        mock_warning.assert_called_once()
+        assert "Device is busy" in mock_warning.call_args[0][2]


### PR DESCRIPTION
- Refactor the wizard into a 4-step layout: Setup, Copy (Optional), Stage, Upload
- Decouple file copying from database registration into separate components
- Add a folder scanner that registers un-tracked images from the staging folder
- Support skipping SD card copy when images are already on the local disk
- Add cross-platform SD card eject support (Linux, macOS, Windows)
- Add options to delete source images and eject SD card after copy
- Update and extend test coverage for the new flows

Closes #3