### PR TITLE
feat(uploader): require image type before staging

### DIFF
--- a/src/uploader.py
+++ b/src/uploader.py
@@ -837,16 +837,13 @@ class UploaderWindow(QMainWindow):
         type_layout = QHBoxLayout()
         type_layout.addWidget(QLabel("Image Type:"))
         self.image_type_combo = QComboBox()
-        self.image_type_combo.addItems(
-            [
-                "survey",
-                "training_true",
-                "training_false",
-            ]
-        )
+        self.image_type_combo.addItem("(Select image type)", None)
+        for image_type in ("survey", "training_true", "training_false"):
+            self.image_type_combo.addItem(image_type, image_type)
+        self.image_type_combo.setCurrentIndex(0)
         self.image_type_combo.setToolTip("Choose what kind of flight these images are from.")
         type_layout.addWidget(self.image_type_combo)
-        self.image_type_desc = QLabel("Survey flight images")
+        self.image_type_desc = QLabel("Choose the kind of flight these images are from")
         self.image_type_desc.setObjectName("help_text")
         type_layout.addWidget(self.image_type_desc)
         type_layout.addStretch()
@@ -860,7 +857,9 @@ class UploaderWindow(QMainWindow):
         self.stage_btn.setToolTip(
             "Scans your Local Storage Folder and registers un-staged images for upload."
         )
+        self.stage_btn.setEnabled(False)
         layout.addWidget(self.stage_btn)
+        self.image_type_combo.currentIndexChanged.connect(self._on_image_type_index_changed)
 
         # Progress
         self.scan_progress = QProgressBar()
@@ -1150,11 +1149,28 @@ class UploaderWindow(QMainWindow):
     def _update_image_type_desc(self, text: str):
         """Update the descriptive label next to the image type combo."""
         descs = {
+            "(Select image type)": "Choose the kind of flight these images are from",
             "survey": "Survey flight images",
             "training_true": "Training: confirmed meteorite",
             "training_false": "Training: no meteorite",
         }
         self.image_type_desc.setText(descs.get(text, ""))
+
+    def _sync_stage_button_enabled(self):
+        """Enable Stage only when a real type is selected and no folder scan is running."""
+        has_type = self.image_type_combo.currentData() is not None
+        scanning = self.scan_thread is not None and self.scan_thread.isRunning()
+        self.stage_btn.setEnabled(has_type and not scanning)
+
+    def _on_image_type_index_changed(self, _index: int):
+        """Re-evaluate Stage enablement when the image type combo changes."""
+        self._sync_stage_button_enabled()
+
+    def _reset_image_type_selection(self):
+        """Reset image type to placeholder and disable Stage (after SD copy)."""
+        self.image_type_combo.setCurrentIndex(0)
+        self._update_image_type_desc(self.image_type_combo.currentText())
+        self.stage_btn.setEnabled(False)
 
     # ------------------------------------------------------------------
     # Config persistence
@@ -1352,6 +1368,7 @@ class UploaderWindow(QMainWindow):
 
         self.set_banner_state("DONE_COPYING")
         self.update_unstaged_count()
+        self._reset_image_type_selection()
 
         # Eject SD card if requested (runs in background thread)
         if self.eject_sd_checkbox.isChecked() and hasattr(self, "_last_sd_card_path"):
@@ -1410,7 +1427,15 @@ class UploaderWindow(QMainWindow):
             )
             return
 
-        image_type = self.image_type_combo.currentText()
+        image_type = self.image_type_combo.currentData()
+        if image_type is None:
+            QMessageBox.warning(
+                self,
+                "Image Type Required",
+                "Please select an image type before staging images.",
+            )
+            return
+
         upload_key = self.upload_key_edit.text().strip()
         if not upload_key:
             QMessageBox.warning(
@@ -1440,7 +1465,7 @@ class UploaderWindow(QMainWindow):
 
     def on_scan_finished(self, registered, skipped, failed):
         """Handle folder scan completion."""
-        self.stage_btn.setEnabled(True)
+        self._sync_stage_button_enabled()
         self.refresh_unstaged_btn.setEnabled(True)
         self.scan_progress.setValue(0)
         self.scan_status_label.setText("")

--- a/tests/integration/test_mixed_survey_staging.py
+++ b/tests/integration/test_mixed_survey_staging.py
@@ -31,6 +31,7 @@ class TestMixedSurveyStaging:
 
         # Stage batch A
         window.upload_key_edit.setText("survey-key-A")
+        window.image_type_combo.setCurrentText("survey")
         qtbot.mouseClick(window.stage_btn, Qt.MouseButton.LeftButton)
         wait_for_thread_done(qtbot, lambda: window.scan_thread, timeout=15_000)
         process_events()
@@ -39,6 +40,7 @@ class TestMixedSurveyStaging:
         create_test_jpeg(staging_dir / "B_0001.jpg", exif_datetime="2025:06:15 10:33:00")
         create_test_jpeg(staging_dir / "B_0002.jpg", exif_datetime="2025:06:15 10:34:00")
         window.upload_key_edit.setText("survey-key-B")
+        window.image_type_combo.setCurrentText("survey")
         qtbot.mouseClick(window.stage_btn, Qt.MouseButton.LeftButton)
         wait_for_thread_done(qtbot, lambda: window.scan_thread, timeout=15_000)
         process_events()

--- a/tests/test_uploader_ui.py
+++ b/tests/test_uploader_ui.py
@@ -359,3 +359,86 @@ class TestWizardLayout:
         ui_window._on_eject_done(False, "Device is busy")
         mock_warning.assert_called_once()
         assert "Device is busy" in mock_warning.call_args[0][2]
+
+
+# ---------------------------------------------------------------------------
+# Image type placeholder / Stage gate (Issue #4)
+# ---------------------------------------------------------------------------
+
+
+class TestImageTypeDefault:
+    """Placeholder image type gates Stage and resets after SD copy."""
+
+    def test_startup_placeholder_disables_stage(self, ui_window):
+        """On construction, combo is at placeholder and Stage is disabled."""
+        assert ui_window.image_type_combo.currentData() is None
+        assert ui_window.image_type_combo.currentIndex() == 0
+        assert ui_window.stage_btn.isEnabled() is False
+
+    def test_selecting_real_type_enables_stage(self, ui_window):
+        """Selecting a real image type enables Stage and sets currentData()."""
+        ui_window.image_type_combo.setCurrentText("survey")
+        assert ui_window.image_type_combo.currentData() == "survey"
+        assert ui_window.stage_btn.isEnabled() is True
+
+    def test_start_folder_scan_guard_with_placeholder(self, ui_window, monkeypatch):
+        """With placeholder selected, start_folder_scan warns and does not scan."""
+        assert ui_window.image_type_combo.currentData() is None
+
+        mock_warning = MagicMock(return_value=QMessageBox.StandardButton.Ok)
+        monkeypatch.setattr("src.uploader.QMessageBox.warning", mock_warning)
+
+        mock_scanner = MagicMock()
+        monkeypatch.setattr("src.uploader.FolderScanner", mock_scanner)
+
+        ui_window.start_folder_scan()
+
+        mock_warning.assert_called_once()
+        assert mock_warning.call_args[0][1] == "Image Type Required"
+        mock_scanner.assert_not_called()
+        assert ui_window.scan_thread is None
+
+    def test_on_staging_finished_resets_image_type(self, ui_window):
+        """After a successful SD copy, combo resets to placeholder and Stage disables."""
+        ui_window.image_type_combo.setCurrentText("survey")
+        assert ui_window.stage_btn.isEnabled() is True
+
+        ui_window.on_staging_finished(10, 0, 0, False)
+
+        assert ui_window.image_type_combo.currentData() is None
+        assert ui_window.image_type_combo.currentIndex() == 0
+        assert ui_window.stage_btn.isEnabled() is False
+
+    def test_on_staging_finished_aborted_also_resets(self, ui_window):
+        """Aborted SD copy also resets image type to placeholder."""
+        ui_window.image_type_combo.setCurrentText("training_true")
+        assert ui_window.stage_btn.isEnabled() is True
+
+        ui_window.on_staging_finished(3, 0, 1, True)
+
+        assert ui_window.image_type_combo.currentData() is None
+        assert ui_window.image_type_combo.currentIndex() == 0
+        assert ui_window.stage_btn.isEnabled() is False
+
+    def test_combo_change_during_scan_keeps_stage_disabled(self, ui_window, monkeypatch):
+        """Changing image type mid-scan must not re-enable Stage."""
+        ui_window.image_type_combo.setCurrentText("survey")
+        assert ui_window.stage_btn.isEnabled() is True
+
+        mock_thread = MagicMock()
+        mock_thread.isRunning.return_value = True
+        ui_window.scan_thread = mock_thread
+        ui_window.stage_btn.setEnabled(False)
+
+        ui_window.image_type_combo.setCurrentText("training_true")
+
+        assert ui_window.image_type_combo.currentData() == "training_true"
+        assert ui_window.stage_btn.isEnabled() is False
+
+        mock_thread.isRunning.return_value = False
+        monkeypatch.setattr(
+            "src.uploader.QMessageBox.information",
+            MagicMock(return_value=QMessageBox.StandardButton.Ok),
+        )
+        ui_window.on_scan_finished(1, 0, 0)
+        assert ui_window.stage_btn.isEnabled() is True


### PR DESCRIPTION
## Summary
- Require an explicit image type selection before Stage is enabled
- Block folder scan with a clear warning when the placeholder is still selected
- Reset the image type combo to the placeholder after SD copy completes
- Keep Stage disabled during an active folder scan
- Add UI and integration test coverage for the new gating behaviour

Closes #4
