### PR TITLE
feat(uploader): add opt-in delete staging files after upload

### DIFF
--- a/src/upload_manager.py
+++ b/src/upload_manager.py
@@ -44,12 +44,14 @@ class UploadManager(QThread):
         state_manager,
         stats_tracker: StatsTracker,
         base_url: str = "https://find.gfo.rocks",
+        delete_staging_after_upload: bool = False,
     ):
         super().__init__()
         self.upload_key = upload_key
         self.state_manager = state_manager
         self.stats_tracker = stats_tracker
         self.base_url = base_url
+        self.delete_staging_after_upload = delete_staging_after_upload
 
         self._should_stop = False
         self._paused = False
@@ -173,8 +175,8 @@ class UploadManager(QThread):
                 logger.info(f"{filename} already uploaded, marking as complete")
                 self.state_manager.update_image_status(image_id, "uploaded")
 
-                # Remove the file
-                if file_path.exists():
+                # Optionally remove the staging file
+                if self.delete_staging_after_upload and file_path.exists():
                     try:
                         file_path.unlink()
                     except Exception as e:
@@ -200,8 +202,8 @@ class UploadManager(QThread):
                     self.stats_tracker.record_upload(file_size)
                     self.state_manager.update_image_status(image_id, "uploaded")
 
-                    # Remove the file
-                    if file_path.exists():
+                    # Optionally remove the staging file
+                    if self.delete_staging_after_upload and file_path.exists():
                         try:
                             file_path.unlink()
                         except Exception as e:

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -1037,6 +1037,17 @@ class UploaderWindow(QMainWindow):
         concurrency_hint.setObjectName("help_text")
         adv_layout.addWidget(concurrency_hint)
 
+        self.delete_staging_checkbox = QCheckBox("Delete local staging files after upload")
+        self.delete_staging_checkbox.setChecked(
+            bool(self.config.get("delete_staging_after_upload", False))
+        )
+        self.delete_staging_checkbox.setToolTip(
+            "If checked, each file is removed from the local storage folder after a successful "
+            "upload. Off by default so uploaded copies remain on disk for safety."
+        )
+        self.delete_staging_checkbox.toggled.connect(self.save_config)
+        adv_layout.addWidget(self.delete_staging_checkbox)
+
         self.advanced_group.setLayout(adv_layout)
         self.advanced_group.setVisible(False)
         layout.addWidget(self.advanced_group)
@@ -1178,6 +1189,7 @@ class UploaderWindow(QMainWindow):
         self.config["staging_dir"] = self.staging_dir_edit.text()
         self.config["concurrency_mode"] = "auto" if self.auto_radio.isChecked() else "manual"
         self.config["concurrency_value"] = self.worker_spin.value()
+        self.config["delete_staging_after_upload"] = self.delete_staging_checkbox.isChecked()
         self.config["dark_mode"] = self._dark_mode
 
         try:
@@ -1521,7 +1533,11 @@ class UploaderWindow(QMainWindow):
         # Start upload thread
         base_url = self.config.get("base_url", "https://find.gfo.rocks")
         self.upload_thread = UploadManager(
-            upload_key, self.state_manager, self.stats_tracker, base_url=base_url
+            upload_key,
+            self.state_manager,
+            self.stats_tracker,
+            base_url=base_url,
+            delete_staging_after_upload=self.delete_staging_checkbox.isChecked(),
         )
 
         if self.auto_radio.isChecked():

--- a/tests/integration/test_already_uploaded.py
+++ b/tests/integration/test_already_uploaded.py
@@ -4,7 +4,7 @@ Integration test: Already-uploaded images — check endpoint returns '1', skip r
 Verifies that when the server says an image already exists:
 - The upload endpoint is never called
 - The image is marked "uploaded" in the DB
-- The local staging file is deleted
+- The local staging file is kept by default (deleted only when opt-in is enabled)
 """
 
 import pytest
@@ -45,6 +45,39 @@ class TestAlreadyUploaded:
                 m.post(CHECK_URL, status=200, body="1")
 
             # Do NOT register UPLOAD_URL — if code hits it, aioresponses raises
+
+            qtbot.mouseClick(window.upload_start_btn, Qt.MouseButton.LeftButton)
+            assert window.upload_thread is not None
+
+            wait_for_thread_done(qtbot, lambda: window.upload_thread, timeout=30_000)
+            process_events()
+
+        counts = integration_state_manager.get_image_counts()
+        assert counts["uploaded"] == n
+        assert counts["staged"] == 0
+        assert counts["failed"] == 0
+
+        # Default: keep staging files when already-uploaded is detected
+        remaining = list(staging_dir.glob("*.jpg"))
+        assert len(remaining) == n
+
+    def test_already_uploaded_deletes_staging_when_opt_in(
+        self,
+        qtbot,
+        app_window,
+        upload_key,
+        integration_state_manager,
+        staging_dir,
+        pre_staged_images,
+    ):
+        """When Advanced Setting is checked, already-uploaded still deletes staging files."""
+        window = app_window
+        n = len(pre_staged_images)
+        window.delete_staging_checkbox.setChecked(True)
+
+        with aioresponses() as m:
+            for _ in range(n):
+                m.post(CHECK_URL, status=200, body="1")
 
             qtbot.mouseClick(window.upload_start_btn, Qt.MouseButton.LeftButton)
             assert window.upload_thread is not None

--- a/tests/integration/test_happy_path.py
+++ b/tests/integration/test_happy_path.py
@@ -9,7 +9,8 @@ Exercises the full user flow:
 5. User clicks "Start Upload"
 6. All images pass the check_uploaded pre-flight (not yet uploaded)
 7. All images upload successfully
-8. DB shows all images as "uploaded", staging files are deleted
+8. DB shows all images as "uploaded"; staging files are kept by default
+   (opt-in Advanced Setting deletes them when checked)
 """
 
 import pytest
@@ -134,6 +135,40 @@ class TestHappyPathUpload:
         """All staged images upload successfully."""
         window = app_window
         n = len(pre_staged_images)
+
+        with aioresponses() as m:
+            for _ in range(n):
+                m.post(CHECK_URL, status=200, body="0")
+                m.post(UPLOAD_URL, status=200, body="SUCCESS")
+
+            qtbot.mouseClick(window.upload_start_btn, Qt.MouseButton.LeftButton)
+            assert window.upload_thread is not None
+
+            wait_for_thread_done(qtbot, lambda: window.upload_thread, timeout=30_000)
+            process_events()
+
+        counts = integration_state_manager.get_image_counts()
+        assert counts["uploaded"] == n
+        assert counts["staged"] == 0
+        assert counts["failed"] == 0
+
+        # Default: keep staging files after successful upload
+        remaining = list(staging_dir.glob("*.jpg"))
+        assert len(remaining) == n
+
+    def test_upload_deletes_staging_when_opt_in(
+        self,
+        qtbot,
+        app_window,
+        upload_key,
+        integration_state_manager,
+        staging_dir,
+        pre_staged_images,
+    ):
+        """When Advanced Setting is checked, staging files are deleted after upload."""
+        window = app_window
+        n = len(pre_staged_images)
+        window.delete_staging_checkbox.setChecked(True)
 
         with aioresponses() as m:
             for _ in range(n):

--- a/tests/test_upload_manager.py
+++ b/tests/test_upload_manager.py
@@ -260,3 +260,100 @@ async def test_upload_single_image_missing_upload_key_fails_fast(tmp_path, manag
     assert result is False
     assert client.check_image_uploaded.call_count == 0
     assert client.upload_image.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# delete_staging_after_upload
+# ---------------------------------------------------------------------------
+
+
+def _image_data(image_file: Path, image_id: int = 1) -> dict:
+    return {
+        "id": image_id,
+        "filename": image_file.name,
+        "staging_path": str(image_file),
+        "image_type": "survey",
+        "upload_key": "survey-key-row",
+        "file_size": image_file.stat().st_size,
+    }
+
+
+class TestDeleteStagingAfterUpload:
+    def test_default_flag_is_false(self, manager):
+        assert manager.delete_staging_after_upload is False
+
+    @pytest.mark.asyncio
+    async def test_success_keeps_staging_file_by_default(self, tmp_path, manager):
+        image_file = tmp_path / "keep.jpg"
+        image_file.write_bytes(b"abc")
+
+        client = MagicMock()
+        client.check_image_uploaded = AsyncMock(return_value=False)
+        client.upload_image = AsyncMock(return_value=(True, "SUCCESS"))
+
+        result = await manager._upload_single_image(client, _image_data(image_file))
+
+        assert result is True
+        assert image_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_success_deletes_staging_file_when_flag_true(
+        self, tmp_path, mock_state_manager, stats_tracker
+    ):
+        image_file = tmp_path / "delete.jpg"
+        image_file.write_bytes(b"abc")
+
+        m = UploadManager(
+            upload_key="test-key",
+            state_manager=mock_state_manager,
+            stats_tracker=stats_tracker,
+            delete_staging_after_upload=True,
+        )
+
+        client = MagicMock()
+        client.check_image_uploaded = AsyncMock(return_value=False)
+        client.upload_image = AsyncMock(return_value=(True, "SUCCESS"))
+
+        result = await m._upload_single_image(client, _image_data(image_file))
+
+        assert result is True
+        assert not image_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_already_uploaded_keeps_staging_file_by_default(self, tmp_path, manager):
+        image_file = tmp_path / "already.jpg"
+        image_file.write_bytes(b"abc")
+
+        client = MagicMock()
+        client.check_image_uploaded = AsyncMock(return_value=True)
+        client.upload_image = AsyncMock()
+
+        result = await manager._upload_single_image(client, _image_data(image_file))
+
+        assert result is True
+        assert image_file.exists()
+        assert client.upload_image.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_already_uploaded_deletes_staging_file_when_flag_true(
+        self, tmp_path, mock_state_manager, stats_tracker
+    ):
+        image_file = tmp_path / "already-delete.jpg"
+        image_file.write_bytes(b"abc")
+
+        m = UploadManager(
+            upload_key="test-key",
+            state_manager=mock_state_manager,
+            stats_tracker=stats_tracker,
+            delete_staging_after_upload=True,
+        )
+
+        client = MagicMock()
+        client.check_image_uploaded = AsyncMock(return_value=True)
+        client.upload_image = AsyncMock()
+
+        result = await m._upload_single_image(client, _image_data(image_file))
+
+        assert result is True
+        assert not image_file.exists()
+        assert client.upload_image.call_count == 0

--- a/tests/test_uploader_ui.py
+++ b/tests/test_uploader_ui.py
@@ -238,6 +238,24 @@ class TestAdvancedPanel:
         assert not ui_window.advanced_group.isVisible()
         assert "Show" in ui_window.advanced_toggle_btn.text()
 
+    def test_delete_staging_checkbox_exists_unchecked(self, ui_window):
+        """Advanced Settings has delete-staging checkbox, default unchecked."""
+        assert hasattr(ui_window, "delete_staging_checkbox")
+        assert ui_window.delete_staging_checkbox.isChecked() is False
+        assert ui_window.delete_staging_checkbox.parent() is ui_window.advanced_group
+
+    def test_delete_staging_checkbox_persists_to_config(self, ui_window):
+        """Toggling delete-staging checkbox writes delete_staging_after_upload."""
+        ui_window.delete_staging_checkbox.setChecked(True)
+        with open(ui_window.config_file) as f:
+            data = json.load(f)
+        assert data.get("delete_staging_after_upload") is True
+
+        ui_window.delete_staging_checkbox.setChecked(False)
+        with open(ui_window.config_file) as f:
+            data = json.load(f)
+        assert data.get("delete_staging_after_upload") is False
+
 
 # ---------------------------------------------------------------------------
 # Staging speed label tests


### PR DESCRIPTION
## Summary

- Staging files are kept on disk after upload by default so uploaded copies remain available locally
- Added an Advanced Settings checkbox to opt in to deleting staging files after successful upload
- Upload manager respects the setting for both fresh uploads and already-uploaded skips
- Preference is saved in config and covered by unit and integration tests

Closes #10
