### PR TITLE
feat(uploader): add orthomosaic image type support

### DIFF
--- a/src/api_client.py
+++ b/src/api_client.py
@@ -68,7 +68,7 @@ class APIClient:
 
         Args:
             upload_key: Survey upload key (UUID)
-            image_type: One of 'survey', 'training_true', 'training_false'
+            image_type: One of 'survey', 'training_true', 'training_false', 'orthomosaic'
             file_path: Path to the image file
 
         Returns:

--- a/src/state_manager.py
+++ b/src/state_manager.py
@@ -10,6 +10,8 @@ from typing import Optional, List, Dict, Any
 from datetime import datetime
 from contextlib import contextmanager
 
+VALID_IMAGE_TYPES = frozenset({"survey", "training_true", "training_false", "orthomosaic"})
+
 
 class StateManager:
     """Singleton class for managing application state with thread-safe SQLite access."""
@@ -69,7 +71,7 @@ class StateManager:
                     filename TEXT NOT NULL,
                     staging_path TEXT NOT NULL,
                     upload_key TEXT,
-                    image_type TEXT NOT NULL CHECK(image_type IN ('survey', 'training_true', 'training_false')),
+                    image_type TEXT NOT NULL,
                     status TEXT NOT NULL CHECK(status IN ('pending', 'staging', 'staged', 'uploading', 'uploaded', 'failed')),
                     exif_timestamp TEXT,
                     file_size INTEGER,
@@ -134,6 +136,43 @@ class StateManager:
             if "upload_key" not in col_names:
                 conn.execute("ALTER TABLE images ADD COLUMN upload_key TEXT")
 
+            self._migrate_image_type_check_constraint(conn)
+
+    def _migrate_image_type_check_constraint(self, conn: sqlite3.Connection) -> None:
+        """Drop legacy image_type CHECK so new types (e.g. orthomosaic) can be stored."""
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='images'"
+        ).fetchone()
+        if not row or "CHECK(image_type IN" not in row["sql"]:
+            return
+
+        conn.executescript(
+            """
+            BEGIN;
+            CREATE TABLE images_new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                filename TEXT NOT NULL,
+                staging_path TEXT NOT NULL,
+                upload_key TEXT,
+                image_type TEXT NOT NULL,
+                status TEXT NOT NULL CHECK(status IN ('pending', 'staging', 'staged', 'uploading', 'uploaded', 'failed')),
+                exif_timestamp TEXT,
+                file_size INTEGER,
+                retry_count INTEGER DEFAULT 0,
+                add_timestamp TEXT DEFAULT CURRENT_TIMESTAMP,
+                upload_timestamp TEXT,
+                error_message TEXT,
+                UNIQUE(staging_path)
+            );
+            INSERT INTO images_new SELECT * FROM images;
+            DROP TABLE images;
+            ALTER TABLE images_new RENAME TO images;
+            CREATE INDEX IF NOT EXISTS idx_images_status ON images(status);
+            CREATE INDEX IF NOT EXISTS idx_images_exif_timestamp ON images(exif_timestamp);
+            COMMIT;
+            """
+        )
+
     def add_image(
         self,
         filename: str,
@@ -144,6 +183,9 @@ class StateManager:
         file_size: Optional[int] = None,
     ) -> int:
         """Add a new image to the database."""
+        if image_type not in VALID_IMAGE_TYPES:
+            raise ValueError(f"Invalid image_type: {image_type!r}")
+
         with self.transaction() as conn:
             cursor = conn.execute(
                 """

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -842,7 +842,7 @@ class UploaderWindow(QMainWindow):
         type_layout.addWidget(QLabel("Image Type:"))
         self.image_type_combo = QComboBox()
         self.image_type_combo.addItem("(Select image type)", None)
-        for image_type in ("survey", "training_true", "training_false"):
+        for image_type in ("survey", "training_true", "training_false", "orthomosaic"):
             self.image_type_combo.addItem(image_type, image_type)
         self.image_type_combo.setCurrentIndex(0)
         self.image_type_combo.setToolTip("Choose what kind of flight these images are from.")
@@ -1168,6 +1168,7 @@ class UploaderWindow(QMainWindow):
             "survey": "Survey flight images",
             "training_true": "Training: confirmed meteorite",
             "training_false": "Training: no meteorite",
+            "orthomosaic": "Low-res images for orthomosaic processing",
         }
         self.image_type_desc.setText(descs.get(text, ""))
 

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -303,3 +303,98 @@ def test_init_db_migrates_upload_key_column_for_legacy_db(tmp_path, monkeypatch)
 
     monkeypatch.setattr(StateManager, "__init__", original_init)
     StateManager._instance = None
+
+
+def test_add_orthomosaic_image(mock_state_manager):
+    """Orthomosaic image type can be persisted on a fresh database."""
+    image_id = mock_state_manager.add_image(
+        filename="ortho.jpg",
+        staging_path="/tmp/ortho.jpg",
+        upload_key="survey-key-1",
+        image_type="orthomosaic",
+    )
+    assert image_id > 0
+
+    images = mock_state_manager.get_staged_images()
+    row = next(i for i in images if i["filename"] == "ortho.jpg")
+    assert row["image_type"] == "orthomosaic"
+
+
+def test_add_image_rejects_invalid_type(mock_state_manager):
+    """add_image rejects image types outside VALID_IMAGE_TYPES."""
+    with pytest.raises(ValueError, match="Invalid image_type"):
+        mock_state_manager.add_image(
+            filename="bad.jpg",
+            staging_path="/tmp/bad.jpg",
+            upload_key="survey-key-1",
+            image_type="not_a_real_type",
+        )
+
+
+def test_init_db_migrates_image_type_check_for_legacy_db(tmp_path, monkeypatch):
+    """_init_db drops legacy image_type CHECK so orthomosaic rows can be stored."""
+    db_path = tmp_path / "legacy_check_state.db"
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE images (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            filename TEXT NOT NULL,
+            staging_path TEXT NOT NULL,
+            upload_key TEXT,
+            image_type TEXT NOT NULL CHECK(image_type IN ('survey', 'training_true', 'training_false')),
+            status TEXT NOT NULL CHECK(status IN ('pending', 'staging', 'staged', 'uploading', 'uploaded', 'failed')),
+            exif_timestamp TEXT,
+            file_size INTEGER,
+            retry_count INTEGER DEFAULT 0,
+            add_timestamp TEXT DEFAULT CURRENT_TIMESTAMP,
+            upload_timestamp TEXT,
+            error_message TEXT,
+            UNIQUE(staging_path)
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO images (filename, staging_path, upload_key, image_type, status)
+        VALUES ('legacy.jpg', '/tmp/legacy.jpg', 'survey-key-1', 'survey', 'staged')
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    original_init = StateManager.__init__
+
+    def mock_init(self):
+        if not hasattr(self, "initialized"):
+            self.db_path = db_path
+            self.conn_lock = __import__("threading").Lock()
+            self._init_db()
+            self.initialized = True
+
+    monkeypatch.setattr(StateManager, "__init__", mock_init)
+    StateManager._instance = None
+    manager = StateManager()
+
+    images = manager.get_staged_images()
+    assert len(images) == 1
+    assert images[0]["image_type"] == "survey"
+
+    ortho_id = manager.add_image(
+        filename="ortho.jpg",
+        staging_path="/tmp/ortho.jpg",
+        upload_key="survey-key-1",
+        image_type="orthomosaic",
+    )
+    assert ortho_id > 0
+
+    conn = sqlite3.connect(db_path)
+    ddl = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='images'"
+    ).fetchone()[0]
+    conn.close()
+    assert "CHECK(image_type IN" not in ddl
+
+    monkeypatch.setattr(StateManager, "__init__", original_init)
+    StateManager._instance = None

--- a/tests/test_uploader_ui.py
+++ b/tests/test_uploader_ui.py
@@ -518,3 +518,19 @@ class TestImageTypeDefault:
         )
         ui_window.on_scan_finished(1, 0, 0)
         assert ui_window.stage_btn.isEnabled() is True
+
+
+class TestOrthomosaicImageType:
+    """Orthomosaic image type option (Issue #13)."""
+
+    def test_combo_includes_orthomosaic(self, ui_window):
+        """Image type combo lists orthomosaic alongside the three existing types."""
+        combo = ui_window.image_type_combo
+        types = [combo.itemData(i) for i in range(combo.count()) if combo.itemData(i) is not None]
+        assert types == ["survey", "training_true", "training_false", "orthomosaic"]
+
+    def test_orthomosaic_description(self, ui_window):
+        """Selecting orthomosaic shows the low-res orthomosaic helper text."""
+        ui_window.image_type_combo.setCurrentText("orthomosaic")
+        assert ui_window.image_type_combo.currentData() == "orthomosaic"
+        assert ui_window.image_type_desc.text() == "Low-res images for orthomosaic processing"


### PR DESCRIPTION
- add orthomosaic as a supported image type in the uploader flow
- migrate legacy image records so the new type can be stored safely
- add regression coverage for persistence, migration, and ui behavior

Closes #13
