### PR TITLE
fix(progress): sync progress bar with upload status

### DIFF
--- a/src/uploader.py
+++ b/src/uploader.py
@@ -1658,7 +1658,14 @@ class UploaderWindow(QMainWindow):
         self.workers_label.setText("")
         self.set_banner_state("COMPLETE")
         self.log("Upload finished")
-        self.update_counts()
+        counts = self.update_counts()
+        uploaded = counts.get("uploaded", 0)
+        failed = counts.get("failed", 0)
+        active = counts.get("staged", 0) + counts.get("uploading", 0)
+        total = uploaded + failed + active
+        if active == 0 and total > 0:
+            self.upload_progress.setMaximum(total)
+            self.upload_progress.setValue(uploaded + failed)
 
     # ------------------------------------------------------------------
     # Image counts & statistics display
@@ -1670,6 +1677,7 @@ class UploaderWindow(QMainWindow):
         self.uploaded_label.setText(f"Uploaded: {counts.get('uploaded', 0)}")
         self.pending_label.setText(f"Pending: {counts.get('staged', 0)}")
         self.failed_label.setText(f"Failed: {counts.get('failed', 0)}")
+        return counts
 
     def update_display_stats(self):
         """Update statistics display."""

--- a/tests/test_uploader_ui.py
+++ b/tests/test_uploader_ui.py
@@ -438,6 +438,68 @@ class TestWizardLayout:
 
 
 # ---------------------------------------------------------------------------
+# Upload completion progress tests
+# ---------------------------------------------------------------------------
+
+
+class TestUploadCompletionProgress:
+    """Final upload UI reconciliation."""
+
+    def test_upload_finished_reconciles_stale_progress_bar(self, ui_window, tmp_path):
+        """A stale partial progress bar is filled when final counts are complete."""
+        for index in range(3):
+            image_id = ui_window.state_manager.add_image(
+                filename=f"image-{index}.jpg",
+                staging_path=str(tmp_path / f"image-{index}.jpg"),
+                upload_key="test-key",
+                image_type="survey",
+            )
+            ui_window.state_manager.update_image_status(image_id, "uploaded")
+
+        ui_window.upload_progress.setMaximum(3)
+        ui_window.upload_progress.setValue(2)
+        ui_window.upload_start_btn.setEnabled(False)
+        ui_window.upload_pause_btn.setEnabled(True)
+        ui_window.upload_stop_btn.setEnabled(True)
+
+        ui_window.on_upload_finished()
+
+        assert ui_window.upload_progress.maximum() == 3
+        assert ui_window.upload_progress.value() == 3
+        assert "3" in ui_window.uploaded_label.text()
+        assert "0" in ui_window.pending_label.text()
+        assert ui_window.upload_start_btn.isEnabled()
+        assert not ui_window.upload_pause_btn.isEnabled()
+        assert not ui_window.upload_stop_btn.isEnabled()
+
+    def test_upload_finished_does_not_force_incomplete_queue_complete(self, ui_window, tmp_path):
+        """Pending work keeps the existing progress value instead of forcing 100%."""
+        uploaded_id = ui_window.state_manager.add_image(
+            filename="uploaded.jpg",
+            staging_path=str(tmp_path / "uploaded.jpg"),
+            upload_key="test-key",
+            image_type="survey",
+        )
+        ui_window.state_manager.update_image_status(uploaded_id, "uploaded")
+        ui_window.state_manager.add_image(
+            filename="pending.jpg",
+            staging_path=str(tmp_path / "pending.jpg"),
+            upload_key="test-key",
+            image_type="survey",
+        )
+
+        ui_window.upload_progress.setMaximum(2)
+        ui_window.upload_progress.setValue(1)
+
+        ui_window.on_upload_finished()
+
+        assert ui_window.upload_progress.maximum() == 2
+        assert ui_window.upload_progress.value() == 1
+        assert "1" in ui_window.uploaded_label.text()
+        assert "1" in ui_window.pending_label.text()
+
+
+# ---------------------------------------------------------------------------
 # Image type placeholder / Stage gate (Issue #4)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
- Update progress calculations so the progress bar follows the current upload state
- Keep displayed progress consistent with staged, active, completed, and failed items
- Add coverage for status-driven progress updates

## Testing
- `poetry install --with dev`
- `QT_QPA_PLATFORM=offscreen poetry run black --check --line-length 100 src tests`
- `QT_QPA_PLATFORM=offscreen poetry run pytest`
- `QT_QPA_PLATFORM=offscreen ./test_coverage.sh`

Closes #20
