### PR TITLE
feat(staging): confirm survey before staging images

### DIFF
--- a/src/api_client.py
+++ b/src/api_client.py
@@ -12,6 +12,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+class SurveyLookupError(Exception):
+    """Raised when the webapp cannot resolve an upload key to a survey name."""
+
+
 class APIClient:
     """Client for DFN webapp upload API."""
 
@@ -58,6 +62,59 @@ class APIClient:
                     return False
         except aiohttp.ClientError as e:
             logger.error(f"Error checking if image uploaded: {e}")
+            raise
+
+    async def resolve_survey_name(self, upload_key: str) -> str:
+        """
+        Resolve an upload key to a displayable survey name.
+
+        Args:
+            upload_key: Survey upload key.
+
+        Returns:
+            Non-empty survey display name.
+
+        Raises:
+            RuntimeError: If the client is not open.
+            SurveyLookupError: If the key cannot be resolved or the response is invalid.
+            aiohttp.ClientError: For network failures.
+        """
+        if not self.session:
+            raise RuntimeError("APIClient must be used as context manager")
+
+        url = f"{self.base_url}/survey/upload/resolve/"
+        data = {"key": upload_key}
+
+        try:
+            async with self.session.post(url, data=data) as response:
+                if response.status == 404:
+                    raise SurveyLookupError("Upload Key was not recognised by the webapp.")
+                if response.status >= 500:
+                    raise SurveyLookupError(
+                        "The webapp could not confirm this Upload Key right now "
+                        f"(HTTP {response.status})."
+                    )
+                if response.status != 200:
+                    raise SurveyLookupError(
+                        f"The webapp could not confirm this Upload Key (HTTP {response.status})."
+                    )
+
+                try:
+                    payload = await response.json()
+                except Exception as e:
+                    raise SurveyLookupError(
+                        "The webapp returned an invalid survey lookup response."
+                    ) from e
+
+                survey_name = str(payload.get("survey_name") or "").strip()
+                if not survey_name:
+                    raise SurveyLookupError(
+                        "The webapp did not return a survey name for this Upload Key."
+                    )
+
+                return survey_name
+        except aiohttp.ClientError:
+            logger.error("Network error resolving survey name", exc_info=True)
             raise
 
     async def upload_image(

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -7,6 +7,7 @@ numbered wizard-step layout, plain-English instructions.
 
 import sys
 import json
+import asyncio
 from pathlib import Path
 from PySide6.QtWidgets import (
     QApplication,
@@ -46,6 +47,7 @@ from .state_manager import StateManager
 from .sd_monitor import SDMonitor, eject_device
 from .staging import StagingCopier, FolderScanner
 from .upload_manager import UploadManager
+from .api_client import APIClient, SurveyLookupError
 from .stats_tracker import StatsTracker
 
 logger = logging.getLogger(__name__)
@@ -178,6 +180,50 @@ class _UnstagedCounter(QThread):
             text = f"Error scanning: {e}"
 
         self.result_ready.emit(text)
+
+
+class _StagingPreflightWorker(QThread):
+    """Count unstaged images and resolve the survey without blocking the UI."""
+
+    result_ready = Signal(int, str, str)
+    error = Signal(str)
+
+    def __init__(self, staging_dir_text: str, upload_key: str, state_manager, parent=None):
+        super().__init__(parent)
+        self._staging_dir_text = staging_dir_text
+        self._upload_key = upload_key
+        self._state_manager = state_manager
+
+    def _count_unstaged_images(self) -> int:
+        from .staging import IMAGE_EXTENSIONS
+
+        staging_dir = Path(self._staging_dir_text)
+        image_paths = []
+        for ext in {e.lower() for e in IMAGE_EXTENSIONS}:
+            if self.isInterruptionRequested():
+                return 0
+            pattern = f"*{''.join(f'[{c.lower()}{c.upper()}]' if c.isalpha() else c for c in ext)}"
+            image_paths.extend(staging_dir.rglob(pattern))
+
+        all_images = [p for p in dict.fromkeys(image_paths) if p.is_file()]
+        known_paths = self._state_manager.get_all_staging_paths()
+        return sum(1 for p in all_images if str(p) not in known_paths)
+
+    async def _resolve_survey_name(self) -> str:
+        async with APIClient() as client:
+            return await client.resolve_survey_name(self._upload_key)
+
+    def run(self):
+        try:
+            unstaged_count = self._count_unstaged_images()
+            if self.isInterruptionRequested():
+                return
+            survey_name = asyncio.run(self._resolve_survey_name())
+            self.result_ready.emit(unstaged_count, survey_name, self._upload_key)
+        except SurveyLookupError as e:
+            self.error.emit(str(e))
+        except Exception as e:
+            self.error.emit(f"Could not confirm this Upload Key: {e}")
 
 
 def _build_stylesheet(p: dict, check_svg: str = "") -> str:
@@ -602,6 +648,7 @@ class UploaderWindow(QMainWindow):
         self.stats_tracker = StatsTracker()
         self.staging_thread = None
         self.scan_thread = None
+        self.preflight_thread = None
         self.upload_thread = None
 
         # Theme state (default dark)
@@ -1200,10 +1247,12 @@ class UploaderWindow(QMainWindow):
         self.image_type_desc.setText(descs.get(text, ""))
 
     def _sync_stage_button_enabled(self):
-        """Enable Stage only when a real type is selected and no folder scan is running."""
+        """Enable Stage only when a real type is selected and no staging work is running."""
         has_type = self.image_type_combo.currentData() is not None
         scanning = self.scan_thread is not None and self.scan_thread.isRunning()
-        self.stage_btn.setEnabled(has_type and not scanning)
+        preflight_thread = getattr(self, "preflight_thread", None)
+        preflighting = preflight_thread is not None and preflight_thread.isRunning()
+        self.stage_btn.setEnabled(has_type and not scanning and not preflighting)
 
     def _on_image_type_index_changed(self, _index: int):
         """Re-evaluate Stage enablement when the image type combo changes."""
@@ -1464,7 +1513,7 @@ class UploaderWindow(QMainWindow):
     # ------------------------------------------------------------------
 
     def start_folder_scan(self):
-        """Start scanning the staging folder and registering images."""
+        """Start the preflight confirmation before registering images."""
         staging_dir = Path(self.staging_dir_edit.text())
         if not staging_dir.exists():
             QMessageBox.warning(
@@ -1493,6 +1542,72 @@ class UploaderWindow(QMainWindow):
             )
             return
 
+        self.preflight_thread = _StagingPreflightWorker(
+            str(staging_dir), upload_key, self.state_manager
+        )
+        self.preflight_thread.result_ready.connect(
+            lambda count, survey_name, resolved_key: self.on_staging_preflight_ready(
+                staging_dir, image_type, resolved_key, count, survey_name
+            )
+        )
+        self.preflight_thread.error.connect(self.on_staging_preflight_error)
+
+        self.stage_btn.setEnabled(False)
+        self.refresh_unstaged_btn.setEnabled(False)
+        self.scan_progress.setValue(0)
+        self.scan_status_label.setText("Confirming Upload Key...")
+        self.preflight_thread.start()
+        self.log(f"Confirming Upload Key before staging {image_type} images...")
+
+    def on_staging_preflight_ready(
+        self,
+        staging_dir: Path,
+        image_type: str,
+        upload_key: str,
+        image_count: int,
+        survey_name: str,
+    ):
+        """Ask the user to confirm the resolved survey before staging."""
+        self.preflight_thread = None
+        self.scan_status_label.setText("Upload Key confirmed")
+        self.refresh_unstaged_btn.setEnabled(True)
+
+        msg = (
+            f"You are about to stage {image_count} images of type {image_type} "
+            f"for upload to survey {survey_name}.\n\n"
+            "Proceed?"
+        )
+        reply = QMessageBox.question(
+            self,
+            "Confirm Staging",
+            msg,
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if reply != QMessageBox.Yes:
+            self.scan_status_label.setText("Staging cancelled")
+            self._sync_stage_button_enabled()
+            self.log("Staging cancelled before registration.")
+            return
+
+        self._start_folder_scan_after_confirmation(staging_dir, image_type, upload_key)
+
+    def on_staging_preflight_error(self, message: str):
+        """Block staging when the Upload Key cannot be resolved."""
+        self.preflight_thread = None
+        self.refresh_unstaged_btn.setEnabled(True)
+        self.scan_status_label.setText("Upload Key could not be confirmed")
+        self._sync_stage_button_enabled()
+        QMessageBox.warning(
+            self,
+            "Upload Key Not Confirmed",
+            f"{message}\n\nStaging has not started. Please check the Upload Key and try again.",
+        )
+        self.log(f"Staging blocked: {message}")
+
+    def _start_folder_scan_after_confirmation(
+        self, staging_dir: Path, image_type: str, upload_key: str
+    ):
+        """Start the existing FolderScanner registration path after confirmation."""
         self.scan_thread = FolderScanner(staging_dir, image_type, upload_key, self.state_manager)
         self.scan_thread.progress.connect(self.on_scan_progress)
         self.scan_thread.finished.connect(self.on_scan_finished)
@@ -1503,7 +1618,7 @@ class UploaderWindow(QMainWindow):
         self.scan_status_label.setText("")
         self.scan_thread.start()
         self.set_banner_state("STAGING")
-        self.log(f"Scanning staging folder for {image_type} images…")
+        self.log(f"Scanning staging folder for {image_type} images...")
 
     def on_scan_progress(self, current, total, filename):
         """Handle folder scan progress update."""
@@ -1793,8 +1908,14 @@ class UploaderWindow(QMainWindow):
             self.staging_thread.wait()
 
         if self.scan_thread and self.scan_thread.isRunning():
-            self.scan_thread.stop()
+            if hasattr(self.scan_thread, "stop"):
+                self.scan_thread.stop()
             self.scan_thread.wait()
+
+        preflight_thread = getattr(self, "preflight_thread", None)
+        if preflight_thread and preflight_thread.isRunning():
+            preflight_thread.requestInterruption()
+            preflight_thread.wait()
 
         if self.upload_thread and self.upload_thread.isRunning():
             self.upload_thread.stop()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,6 +30,7 @@ from src.state_manager import StateManager
 from src.sd_monitor import SDCardInfo
 from src.stats_tracker import StatsTracker
 from src.upload_manager import UploadManager
+from src.api_client import APIClient
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -89,6 +90,35 @@ def process_events():
     app = QApplication.instance()
     if app:
         app.processEvents()
+
+
+class _Signal:
+    """Tiny signal helper for deterministic integration preflight tests."""
+
+    def __init__(self):
+        self._callbacks = []
+
+    def connect(self, callback):
+        self._callbacks.append(callback)
+
+    def emit(self, *args):
+        for callback in list(self._callbacks):
+            callback(*args)
+
+
+class _ImmediatePreflightWorker:
+    """Synchronous preflight replacement used by integration fixtures."""
+
+    def __init__(self, staging_dir_text, upload_key, state_manager, parent=None):
+        self.result_ready = _Signal()
+        self.error = _Signal()
+        self.upload_key = upload_key
+
+    def isRunning(self):
+        return False
+
+    def start(self):
+        self.result_ready.emit(0, f"Survey {self.upload_key}", self.upload_key)
 
 
 # ---------------------------------------------------------------------------
@@ -263,8 +293,15 @@ def app_window(
     monkeypatch.setattr(QMessageBox, "warning", lambda *a, **kw: QMessageBox.StandardButton.Ok)
     monkeypatch.setattr(QMessageBox, "critical", lambda *a, **kw: QMessageBox.StandardButton.Ok)
 
+    async def _fake_resolve_survey_name(self, upload_key):
+        return f"Survey {upload_key}"
+
+    monkeypatch.setattr(APIClient, "resolve_survey_name", _fake_resolve_survey_name)
+
+    from src import uploader as uploader_mod
     from src.uploader import UploaderWindow
 
+    monkeypatch.setattr(uploader_mod, "_StagingPreflightWorker", _ImmediatePreflightWorker)
     monkeypatch.setattr(UploaderWindow, "__init__", _make_patched_init(config_path, staging_dir))
 
     window = UploaderWindow()
@@ -308,6 +345,7 @@ def _make_patched_init(config_path: Path, staging_dir: Path):
         self.stats_tracker = StatsTracker()
         self.staging_thread = None
         self.scan_thread = None
+        self.preflight_thread = None
         self.upload_thread = None
         self._dark_mode = True
 

--- a/tests/integration/test_staging_confirmation.py
+++ b/tests/integration/test_staging_confirmation.py
@@ -1,0 +1,256 @@
+"""Integration tests for the real staging preflight worker and Stage flow (issue #19).
+
+The UI unit tests and the shared ``app_window`` fixture replace
+``_StagingPreflightWorker`` with synchronous stand-ins. These tests instead start
+the real QThread so the actual ``run()`` body, ``asyncio.run`` resolver call, and
+cross-thread signal emission are exercised. The resolver network call is mocked
+with ``aioresponses`` so no live server is contacted.
+"""
+
+import json
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMessageBox
+
+from src.api_client import SurveyLookupError
+from src.uploader import UploaderWindow, _StagingPreflightWorker
+
+from .conftest import _make_patched_init, create_test_jpeg, process_events
+
+
+pytestmark = pytest.mark.integration
+
+RESOLVE_URL = "https://find.gfo.rocks/survey/upload/resolve/"
+
+
+def _wait_for_scan_done(qtbot, window, timeout=30_000):
+    """Wait until the FolderScanner has been created and has finished."""
+
+    def _check():
+        t = window.scan_thread
+        return t is not None and not t.isRunning()
+
+    qtbot.waitUntil(_check, timeout=timeout)
+
+
+class TestStagingPreflightWorkerThread:
+    """The real _StagingPreflightWorker QThread (run() body + signals)."""
+
+    def test_emits_count_and_survey_name(self, qtbot, staging_dir, integration_state_manager):
+        create_test_jpeg(staging_dir / "img1.jpg")
+        create_test_jpeg(staging_dir / "img2.jpg")
+
+        results = []
+        errors = []
+        worker = _StagingPreflightWorker(str(staging_dir), "survey-key", integration_state_manager)
+        worker.result_ready.connect(lambda *args: results.append(args))
+        worker.error.connect(lambda msg: errors.append(msg))
+
+        with aioresponses() as m:
+            m.post(RESOLVE_URL, status=200, payload={"survey_name": "DFN Survey 001"})
+            worker.start()
+            qtbot.waitUntil(lambda: bool(results) or bool(errors), timeout=15_000)
+            worker.wait(5000)
+
+        assert errors == []
+        assert len(results) == 1
+        count, survey_name, upload_key = results[0]
+        assert count == 2
+        assert survey_name == "DFN Survey 001"
+        assert upload_key == "survey-key"
+
+    def test_counts_only_unstaged_images(self, qtbot, staging_dir, integration_state_manager):
+        create_test_jpeg(staging_dir / "staged.jpg")
+        integration_state_manager.add_image(
+            filename="staged.jpg",
+            staging_path=str(staging_dir / "staged.jpg"),
+            upload_key="survey-key",
+            image_type="survey",
+            exif_timestamp="2025-06-15T10:30:00",
+            file_size=123,
+        )
+        create_test_jpeg(staging_dir / "new.jpg")
+
+        results = []
+        worker = _StagingPreflightWorker(str(staging_dir), "survey-key", integration_state_manager)
+        worker.result_ready.connect(lambda *args: results.append(args))
+
+        with aioresponses() as m:
+            m.post(RESOLVE_URL, status=200, payload={"survey_name": "DFN Survey 001"})
+            worker.start()
+            qtbot.waitUntil(lambda: bool(results), timeout=15_000)
+            worker.wait(5000)
+
+        assert results[0][0] == 1
+
+    def test_emits_error_on_invalid_key(self, qtbot, staging_dir, integration_state_manager):
+        create_test_jpeg(staging_dir / "img1.jpg")
+
+        results = []
+        errors = []
+        worker = _StagingPreflightWorker(str(staging_dir), "bad-key", integration_state_manager)
+        worker.result_ready.connect(lambda *args: results.append(args))
+        worker.error.connect(lambda msg: errors.append(msg))
+
+        with aioresponses() as m:
+            m.post(RESOLVE_URL, status=404, payload={"error": "invalid_upload_key"})
+            worker.start()
+            qtbot.waitUntil(lambda: bool(results) or bool(errors), timeout=15_000)
+            worker.wait(5000)
+
+        assert results == []
+        assert len(errors) == 1
+        assert "not recognised" in errors[0]
+
+    def test_emits_error_on_network_failure(self, qtbot, staging_dir, integration_state_manager):
+        create_test_jpeg(staging_dir / "img1.jpg")
+
+        results = []
+        errors = []
+        worker = _StagingPreflightWorker(str(staging_dir), "survey-key", integration_state_manager)
+        worker.result_ready.connect(lambda *args: results.append(args))
+        worker.error.connect(lambda msg: errors.append(msg))
+
+        with aioresponses() as m:
+            m.post(RESOLVE_URL, exception=aiohttp.ClientConnectionError("network down"))
+            worker.start()
+            qtbot.waitUntil(lambda: bool(results) or bool(errors), timeout=15_000)
+            worker.wait(5000)
+
+        assert results == []
+        assert len(errors) == 1
+        assert "Could not confirm" in errors[0]
+
+
+@pytest.fixture
+def real_preflight_window(
+    qtbot,
+    tmp_path,
+    upload_key,
+    integration_state_manager,
+    staging_dir,
+    monkeypatch,
+):
+    """UploaderWindow wired with the REAL _StagingPreflightWorker.
+
+    Unlike the shared ``app_window`` fixture, this does not replace the preflight
+    worker with a synchronous stand-in, so the real QThread runs. Resolver network
+    calls are mocked per-test with ``aioresponses``.
+    """
+    from src import sd_monitor as sd_mod
+
+    config_path = tmp_path / "config.json"
+    config_data = {
+        "upload_key": upload_key,
+        "staging_dir": str(staging_dir),
+        "concurrency_mode": "auto",
+        "concurrency_value": 3,
+    }
+    config_path.write_text(json.dumps(config_data))
+
+    monkeypatch.setattr(sd_mod.SDMonitor, "_get_removable_devices", lambda self: [])
+    monkeypatch.setattr(sd_mod.SDMonitor, "get_sd_cards", lambda self: [])
+    monkeypatch.setattr(
+        sd_mod.SDMonitor,
+        "check_for_changes",
+        lambda self: {"added": [], "removed": []},
+    )
+
+    monkeypatch.setattr(QMessageBox, "question", lambda *a, **kw: QMessageBox.StandardButton.Yes)
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **kw: QMessageBox.StandardButton.Ok)
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **kw: QMessageBox.StandardButton.Ok)
+    monkeypatch.setattr(QMessageBox, "critical", lambda *a, **kw: QMessageBox.StandardButton.Ok)
+
+    monkeypatch.setattr(UploaderWindow, "__init__", _make_patched_init(config_path, staging_dir))
+
+    window = UploaderWindow()
+    qtbot.addWidget(window)
+    window.show()
+    process_events()
+
+    yield window
+
+    if window.scan_thread and window.scan_thread.isRunning():
+        window.scan_thread.stop()
+        window.scan_thread.wait(5000)
+    preflight = getattr(window, "preflight_thread", None)
+    if preflight and preflight.isRunning():
+        preflight.requestInterruption()
+        preflight.wait(5000)
+    window.close()
+    process_events()
+
+
+class TestStageFlowWithRealPreflight:
+    """Full Stage flow using the real preflight worker and FolderScanner."""
+
+    def test_proceed_registers_images_with_staged_key(
+        self, qtbot, real_preflight_window, staging_dir, integration_state_manager
+    ):
+        window = real_preflight_window
+        create_test_jpeg(staging_dir / "a.jpg")
+        create_test_jpeg(staging_dir / "b.jpg")
+
+        window.upload_key_edit.setText("survey-key")
+        window.image_type_combo.setCurrentText("survey")
+
+        with aioresponses() as m:
+            m.post(RESOLVE_URL, status=200, payload={"survey_name": "DFN Survey 001"})
+            qtbot.mouseClick(window.stage_btn, Qt.MouseButton.LeftButton)
+            _wait_for_scan_done(qtbot, window, timeout=30_000)
+            process_events()
+
+        staged = integration_state_manager.get_staged_images()
+        assert len(staged) == 2
+        assert all(img["upload_key"] == "survey-key" for img in staged)
+        assert all(img["image_type"] == "survey" for img in staged)
+
+    def test_cancel_registers_nothing(
+        self, qtbot, real_preflight_window, staging_dir, integration_state_manager, monkeypatch
+    ):
+        window = real_preflight_window
+        create_test_jpeg(staging_dir / "a.jpg")
+
+        monkeypatch.setattr(QMessageBox, "question", lambda *a, **kw: QMessageBox.StandardButton.No)
+
+        window.upload_key_edit.setText("survey-key")
+        window.image_type_combo.setCurrentText("survey")
+
+        with aioresponses() as m:
+            m.post(RESOLVE_URL, status=200, payload={"survey_name": "DFN Survey 001"})
+            qtbot.mouseClick(window.stage_btn, Qt.MouseButton.LeftButton)
+            qtbot.waitUntil(lambda: window.preflight_thread is None, timeout=15_000)
+            process_events()
+
+        assert integration_state_manager.get_staged_images() == []
+        assert window.scan_thread is None
+
+    def test_lookup_failure_blocks_registration(
+        self, qtbot, real_preflight_window, staging_dir, integration_state_manager, monkeypatch
+    ):
+        window = real_preflight_window
+        create_test_jpeg(staging_dir / "a.jpg")
+
+        warnings = []
+        monkeypatch.setattr(
+            QMessageBox,
+            "warning",
+            lambda *args, **kw: warnings.append(args) or QMessageBox.StandardButton.Ok,
+        )
+
+        window.upload_key_edit.setText("bad-key")
+        window.image_type_combo.setCurrentText("survey")
+
+        with aioresponses() as m:
+            m.post(RESOLVE_URL, status=404, payload={"error": "invalid_upload_key"})
+            qtbot.mouseClick(window.stage_btn, Qt.MouseButton.LeftButton)
+            qtbot.waitUntil(lambda: window.preflight_thread is None, timeout=15_000)
+            process_events()
+
+        assert integration_state_manager.get_staged_images() == []
+        assert window.scan_thread is None
+        assert warnings
+        assert "Staging has not started" in warnings[0][2]

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -5,11 +5,11 @@ import aiohttp
 from aioresponses import aioresponses
 from pathlib import Path
 from unittest.mock import patch
-from src.api_client import APIClient
-
+from src.api_client import APIClient, SurveyLookupError
 
 CHECK_URL = "https://find.gfo.rocks/survey/upload/check/"
 UPLOAD_URL = "https://find.gfo.rocks/survey/upload/"
+RESOLVE_URL = "https://find.gfo.rocks/survey/upload/resolve/"
 
 
 @pytest.mark.asyncio
@@ -215,3 +215,81 @@ async def test_upload_image_unknown_extension_uses_octet_stream(tmp_path):
                 assert success is True
 
     assert captured_content_type == "application/octet-stream"
+
+
+@pytest.mark.asyncio
+async def test_resolve_survey_name_success():
+    """Resolve returns the survey display name for a valid upload key."""
+    with aioresponses() as m:
+        m.post(RESOLVE_URL, status=200, payload={"survey_name": "DFN Survey 001"})
+        async with APIClient() as client:
+            assert await client.resolve_survey_name("survey-key") == "DFN Survey 001"
+
+
+@pytest.mark.asyncio
+async def test_resolve_survey_name_invalid_key():
+    """404 resolver response blocks staging as an invalid upload key."""
+    with aioresponses() as m:
+        m.post(RESOLVE_URL, status=404, payload={"error": "invalid_upload_key"})
+        async with APIClient() as client:
+            with pytest.raises(SurveyLookupError, match="not recognised"):
+                await client.resolve_survey_name("bad-key")
+
+
+@pytest.mark.asyncio
+async def test_resolve_survey_name_server_error():
+    """5xx resolver responses are retryable blocking lookup failures."""
+    with aioresponses() as m:
+        m.post(RESOLVE_URL, status=500, body="server error")
+        async with APIClient() as client:
+            with pytest.raises(SurveyLookupError, match="HTTP 500"):
+                await client.resolve_survey_name("survey-key")
+
+
+@pytest.mark.asyncio
+async def test_resolve_survey_name_malformed_json():
+    """Malformed JSON from the resolver blocks staging."""
+    with aioresponses() as m:
+        m.post(RESOLVE_URL, status=200, body="not json")
+        async with APIClient() as client:
+            with pytest.raises(SurveyLookupError, match="invalid survey lookup response"):
+                await client.resolve_survey_name("survey-key")
+
+
+@pytest.mark.asyncio
+async def test_resolve_survey_name_missing_or_blank_name():
+    """Missing or blank survey_name blocks staging."""
+    for payload in ({}, {"survey_name": "   "}):
+        with aioresponses() as m:
+            m.post(RESOLVE_URL, status=200, payload=payload)
+            async with APIClient() as client:
+                with pytest.raises(SurveyLookupError, match="did not return a survey name"):
+                    await client.resolve_survey_name("survey-key")
+
+
+@pytest.mark.asyncio
+async def test_resolve_survey_name_custom_base_url():
+    """Survey resolver respects custom API base URLs."""
+    url = "https://custom.example.com/survey/upload/resolve/"
+    with aioresponses() as m:
+        m.post(url, status=200, payload={"survey_name": "Custom Survey"})
+        async with APIClient("https://custom.example.com") as client:
+            assert await client.resolve_survey_name("survey-key") == "Custom Survey"
+
+
+@pytest.mark.asyncio
+async def test_resolve_survey_name_network_error():
+    """Network resolver failures propagate as ClientError."""
+    with aioresponses() as m:
+        m.post(RESOLVE_URL, exception=aiohttp.ClientError("network down"))
+        async with APIClient() as client:
+            with pytest.raises(aiohttp.ClientError):
+                await client.resolve_survey_name("survey-key")
+
+
+@pytest.mark.asyncio
+async def test_resolve_survey_name_outside_context_manager_raises():
+    """Calling resolver outside the context manager raises."""
+    client = APIClient()
+    with pytest.raises(RuntimeError, match="context manager"):
+        await client.resolve_survey_name("survey-key")

--- a/tests/test_uploader_ui.py
+++ b/tests/test_uploader_ui.py
@@ -45,6 +45,7 @@ def _make_patched_init(config_path: Path, staging_dir: Path):
         self.stats_tracker = StatsTracker()
         self.staging_thread = None
         self.scan_thread = None
+        self.preflight_thread = None
         self.upload_thread = None
         self._dark_mode = True
 
@@ -125,6 +126,42 @@ def _build_ui_window(qtbot, tmp_path, monkeypatch, platform=None):
     qtbot.addWidget(window)
     window.show()
     return window
+
+
+class _Signal:
+    """Tiny signal helper for synchronous worker test doubles."""
+
+    def __init__(self):
+        self._callbacks = []
+
+    def connect(self, callback):
+        self._callbacks.append(callback)
+
+    def emit(self, *args):
+        for callback in list(self._callbacks):
+            callback(*args)
+
+
+class ImmediatePreflightWorker:
+    """Synchronous successful preflight replacement for UI tests."""
+
+    def __init__(self, staging_dir_text, upload_key, state_manager, parent=None):
+        self.result_ready = _Signal()
+        self.error = _Signal()
+        self.upload_key = upload_key
+
+    def isRunning(self):
+        return False
+
+    def start(self):
+        self.result_ready.emit(2, "Resolved Survey", self.upload_key)
+
+
+class FailingPreflightWorker(ImmediatePreflightWorker):
+    """Synchronous failing preflight replacement for UI tests."""
+
+    def start(self):
+        self.error.emit("Upload Key was not recognised by the webapp.")
 
 
 @pytest.fixture(autouse=True)
@@ -595,3 +632,106 @@ class TestOrthomosaicImageType:
         ui_window.image_type_combo.setCurrentText("orthomosaic")
         assert ui_window.image_type_combo.currentData() == "orthomosaic"
         assert ui_window.image_type_desc.text() == "Low-res images for orthomosaic processing"
+
+
+class TestStagingConfirmation:
+    """Stage confirmation resolves the survey before FolderScanner registration."""
+
+    def test_stage_confirmation_cancel_prevents_scanner(self, ui_window, tmp_path, monkeypatch):
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir(exist_ok=True)
+        (staging_dir / "image1.jpg").write_bytes(b"jpg")
+        ui_window.staging_dir_edit.setText(str(staging_dir))
+        ui_window.upload_key_edit.setText("survey-key")
+        ui_window.image_type_combo.setCurrentText("survey")
+
+        scanner_created = []
+        monkeypatch.setattr("src.uploader._StagingPreflightWorker", ImmediatePreflightWorker)
+        monkeypatch.setattr(
+            "src.uploader.QMessageBox.question",
+            lambda *a, **kw: QMessageBox.StandardButton.No,
+        )
+        monkeypatch.setattr(
+            "src.uploader.FolderScanner",
+            lambda *a, **kw: scanner_created.append(a),
+        )
+
+        ui_window.start_folder_scan()
+
+        assert scanner_created == []
+        assert ui_window.stage_btn.isEnabled() is True
+
+    def test_stage_confirmation_proceed_starts_scanner(self, ui_window, tmp_path, monkeypatch):
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir(exist_ok=True)
+        (staging_dir / "image1.jpg").write_bytes(b"jpg")
+        ui_window.staging_dir_edit.setText(str(staging_dir))
+        ui_window.upload_key_edit.setText("survey-key")
+        ui_window.image_type_combo.setCurrentText("survey")
+
+        class Scanner:
+            def __init__(self, *args):
+                self.args = args
+                self.progress = _Signal()
+                self.finished = _Signal()
+                self.started = False
+
+            def isRunning(self):
+                return self.started
+
+            def start(self):
+                self.started = True
+
+            def stop(self):
+                self.started = False
+
+            def wait(self, *_args):
+                return True
+
+        scanner_holder = {}
+
+        def make_scanner(*args):
+            scanner = Scanner(*args)
+            scanner_holder["scanner"] = scanner
+            return scanner
+
+        monkeypatch.setattr("src.uploader._StagingPreflightWorker", ImmediatePreflightWorker)
+        monkeypatch.setattr(
+            "src.uploader.QMessageBox.question",
+            lambda *a, **kw: QMessageBox.StandardButton.Yes,
+        )
+        monkeypatch.setattr("src.uploader.FolderScanner", make_scanner)
+
+        ui_window.start_folder_scan()
+
+        scanner = scanner_holder["scanner"]
+        assert scanner.args[0] == staging_dir
+        assert scanner.args[1] == "survey"
+        assert scanner.args[2] == "survey-key"
+        assert scanner.started is True
+
+    def test_stage_lookup_failure_blocks_scanner(self, ui_window, tmp_path, monkeypatch):
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir(exist_ok=True)
+        ui_window.staging_dir_edit.setText(str(staging_dir))
+        ui_window.upload_key_edit.setText("bad-key")
+        ui_window.image_type_combo.setCurrentText("survey")
+
+        scanner_created = []
+        warning_calls = []
+        monkeypatch.setattr("src.uploader._StagingPreflightWorker", FailingPreflightWorker)
+        monkeypatch.setattr(
+            "src.uploader.FolderScanner",
+            lambda *a, **kw: scanner_created.append(a),
+        )
+        monkeypatch.setattr(
+            "src.uploader.QMessageBox.warning",
+            lambda *args, **kw: warning_calls.append(args) or QMessageBox.StandardButton.Ok,
+        )
+
+        ui_window.start_folder_scan()
+
+        assert scanner_created == []
+        assert warning_calls
+        assert "Staging has not started" in warning_calls[0][2]
+        assert ui_window.stage_btn.isEnabled() is True


### PR DESCRIPTION
- Added an upload-key resolver API call that returns a survey display name and reports invalid, malformed, server-side, and network lookup failures clearly.
- Added a staging preflight worker that counts unstaged images, resolves the survey, and blocks folder registration until the user confirms the target survey.
- Updated the staging UI flow so cancelled or failed confirmation leaves staging untouched and restores controls safely.
- Added API client, UI, and integration test coverage for successful confirmation, cancellation, lookup failure, and resolver edge cases.
- Verification evidence from existing artefacts:
  - full pytest suite passed: 232 passed
  - Black check passed
  - compileall passed

Closes #19
