### PR TITLE
chore(app): rename app to Drone -> Cloud

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,6 +1,6 @@
-# Deployment Guide for DFN Image Uploader
+# Deployment Guide for Drone -> Cloud
 
-This guide covers building platform-specific packages for the DFN Image Uploader.
+This guide covers building platform-specific packages for the Drone -> Cloud application.
 
 ## Prerequisites
 
@@ -41,7 +41,7 @@ poetry install
 poetry add --group dev pyinstaller
 
 # Build single-file executable
-poetry run pyinstaller --name="DFN-Uploader" \
+poetry run pyinstaller --name="DroneToCloud" \
     --windowed \
     --onefile \
     --collect-all PySide6 \
@@ -49,17 +49,17 @@ poetry run pyinstaller --name="DFN-Uploader" \
     --add-data="icon.ico;." \
     src/main.py
 
-# Output will be in dist/DFN-Uploader.exe
+# Output will be in dist/DroneToCloud.exe
 
 # Debug build — opens a console window on launch so runtime errors are visible
-poetry run pyinstaller --name="DFN-Uploader-debug" \
+poetry run pyinstaller --name="DroneToCloud-debug" \
     --onefile \
     --collect-all PySide6 \
     --icon=icon.ico \
     --add-data="icon.ico;." \
     src/main.py
 
-# Output will be in dist/DFN-Uploader-debug.exe
+# Output will be in dist/DroneToCloud-debug.exe
 ```
 
 ### macOS Application Bundle
@@ -69,25 +69,25 @@ poetry run pyinstaller --name="DFN-Uploader-debug" \
 poetry add --group dev pyinstaller
 
 # Build .app bundle
-poetry run pyinstaller --name="DFN Uploader" \
+poetry run pyinstaller --name="DroneToCloud" \
     --windowed \
     --onefile \
     --icon=icon.icns \
     --osx-bundle-identifier=au.csiro.dfn.uploader \
     src/main.py
 
-# Output will be in dist/DFN Uploader.app
+# Output will be in dist/DroneToCloud.app
 
 # Optional: Create DMG
 brew install create-dmg
 create-dmg \
-    --volname "DFN Uploader" \
+    --volname "DroneToCloud" \
     --window-pos 200 120 \
     --window-size 600 300 \
     --icon-size 100 \
     --app-drop-link 450 120 \
-    "DFN-Uploader.dmg" \
-    "dist/DFN Uploader.app"
+    "DroneToCloud.dmg" \
+    "dist/DroneToCloud.app"
 ```
 
 ### Linux AppImage
@@ -110,41 +110,41 @@ mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
 
 # 2. Copy application files
 cp -r src AppDir/usr/bin/
-cp icon.png AppDir/usr/share/icons/hicolor/256x256/apps/dfn-uploader.png
+cp icon.png AppDir/usr/share/icons/hicolor/256x256/apps/DroneToCloud.png
 
 # 3. Create desktop entry
-cat > AppDir/usr/share/applications/dfn-uploader.desktop << EOF
+cat > AppDir/usr/share/applications/DroneToCloud.desktop << EOF
 [Desktop Entry]
 Type=Application
-Name=DFN Uploader
+Name=Drone -> Cloud
 Exec=python -m src.main
-Icon=dfn-uploader
+Icon=DroneToCloud
 Categories=Utility;
 EOF
 
 # 4. Build AppImage
-appimagetool AppDir DFN-Uploader.AppImage
+appimagetool AppDir DroneToCloud.AppImage
 ```
 
 ## Testing Builds
 
 ### Windows
 ```cmd
-dist\DFN-Uploader.exe
-dist\DFN-Uploader-debug.exe
+dist\DroneToCloud.exe
+dist\DroneToCloud-debug.exe
 ```
 
 On Windows, file logs are written to `%APPDATA%\DFN\uploader.log` (not next to the executable).
 
 ### macOS
 ```bash
-open "dist/DFN Uploader.app"
+open "dist/DroneToCloud.app"
 ```
 
 ### Linux
 ```bash
-chmod +x DFN-Uploader.AppImage
-./DFN-Uploader.AppImage
+chmod +x DroneToCloud.AppImage
+./DroneToCloud.AppImage
 ```
 
 ## Continuous Integration
@@ -156,18 +156,18 @@ GitHub Actions workflow can automate builds for all platforms. See `.github/work
 ### Windows
 Use SignTool from Windows SDK:
 ```cmd
-signtool sign /f certificate.pfx /p password /t http://timestamp.digicert.com dist\DFN-Uploader.exe
+signtool sign /f certificate.pfx /p password /t http://timestamp.digicert.com dist\DroneToCloud.exe
 ```
 
 ### macOS
 ```bash
-codesign --deep --force --verify --verbose --sign "Developer ID Application: Your Name" "dist/DFN Uploader.app"
+codesign --deep --force --verify --verbose --sign "Developer ID Application: Your Name" "dist/DroneToCloud.app"
 
 # Notarize with Apple
-xcrun notarytool submit "DFN-Uploader.dmg" --keychain-profile "notarytool-profile" --wait
+xcrun notarytool submit "DroneToCloud.dmg" --keychain-profile "notarytool-profile" --wait
 
 # Staple notarization ticket
-xcrun stapler staple "DFN-Uploader.dmg"
+xcrun stapler staple "DroneToCloud.dmg"
 ```
 
 ## Distribution
@@ -177,9 +177,9 @@ xcrun stapler staple "DFN-Uploader.dmg"
 2. Push the tag: `git push origin v0.1.0`
 3. Create GitHub Release and upload platform-specific packages
 4. Assets should be named:
-   - `DFN-Uploader-v0.1.0-Windows.exe`
-   - `DFN-Uploader-v0.1.0-macOS.dmg`
-   - `DFN-Uploader-v0.1.0-Linux.AppImage`
+   - `DroneToCloud-v0.1.0-Windows.exe`
+   - `DroneToCloud-v0.1.0-macOS.dmg`
+   - `DroneToCloud-v0.1.0-Linux.AppImage`
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# DFN Image Uploader
+# Drone -> Cloud
+
+Batch upload drone images to find.gfo.rocks
 
 Cross-platform GUI application for staging drone survey images from SD cards and uploading them to the DFN webapp with optimized parallel transfers.
 
@@ -27,15 +29,15 @@ Cross-platform GUI application for staging drone survey images from SD cards and
 
 ```bash
 poetry install
-poetry run dfn-uploader
+poetry run drone_to_cloud
 ```
 
 ### Production
 
 Download the appropriate package for your platform:
-- **Windows**: `dfn-uploader.exe`
-- **macOS**: `dfn-uploader.app` or `dfn-uploader.dmg`
-- **Linux**: `dfn-uploader.AppImage`
+- **Windows**: `DroneToCloud.exe`
+- **macOS**: `DroneToCloud.app` or `DroneToCloud.dmg`
+- **Linux**: `DroneToCloud.AppImage`
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ coverage = "^7.3.0"
 piexif = "^1.1.3"
 
 [tool.poetry.scripts]
-dfn-uploader = "src.main:main"
+drone_to_cloud = "src.main:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,5 @@
 """
-Package initialization for DFN uploader.
+Package initialization for Drone -> Cloud.
 """
 
 __version__ = "0.1.0"

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 """
-Entry point for DFN image uploader application.
+Entry point for the Drone -> Cloud application.
 """
 
 import sys
@@ -45,7 +45,7 @@ def main():
 
     try:
         app = QApplication(sys.argv)
-        app.setApplicationName("DFN Image Uploader")
+        app.setApplicationName("Drone -> Cloud")
         app.setOrganizationName("DFN")
         app.setStyle("Fusion")  # Consistent cross-platform base
 

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -1,5 +1,5 @@
 """
-Main GUI application for DFN image uploader.
+Main GUI application for Drone -> Cloud.
 
 Field-optimised UX: high-contrast dark/light themes, large touch targets,
 numbered wizard-step layout, plain-English instructions.
@@ -238,6 +238,15 @@ def _build_stylesheet(p: dict, check_svg: str = "") -> str:
         padding: 8px;
         border-radius: 6px;
         color: #FFFFFF;
+    }}
+    QLabel[objectName="app_title"] {{
+        font-size: 18pt;
+        font-weight: bold;
+        color: {p['text']};
+    }}
+    QLabel[objectName="app_subtitle"] {{
+        font-size: 10pt;
+        color: {p['text_muted']};
     }}
     QLabel[objectName="stat_header"] {{
         font-size: 9pt;
@@ -580,7 +589,7 @@ class UploaderWindow(QMainWindow):
 
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("DFN Image Uploader")
+        self.setWindowTitle("Drone -> Cloud")
         self.setMinimumSize(860, 620)
 
         icon_path = resolve_icon_path()
@@ -636,6 +645,19 @@ class UploaderWindow(QMainWindow):
         main_layout = QVBoxLayout(central_widget)
         main_layout.setSpacing(6)
         main_layout.setContentsMargins(12, 6, 12, 6)
+
+        # -- Header: app title + subtitle --
+        header_layout = QVBoxLayout()
+        header_layout.setSpacing(0)
+        self.app_title_label = QLabel("Drone -> Cloud")
+        self.app_title_label.setObjectName("app_title")
+        self.app_title_label.setAlignment(Qt.AlignCenter)
+        header_layout.addWidget(self.app_title_label)
+        self.app_subtitle_label = QLabel("Batch upload drone images to find.gfo.rocks")
+        self.app_subtitle_label.setObjectName("app_subtitle")
+        self.app_subtitle_label.setAlignment(Qt.AlignCenter)
+        header_layout.addWidget(self.app_subtitle_label)
+        main_layout.addLayout(header_layout)
 
         # -- Top bar: banner + theme toggle --
         top_bar = QHBoxLayout()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """
-Test fixtures and utilities for DFN uploader tests.
+Test fixtures and utilities for Drone -> Cloud tests.
 """
 
 import pytest

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,1 +1,1 @@
-"""Integration tests for the DFN image uploader GUI."""
+"""Integration tests for the Drone -> Cloud GUI."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,7 +31,6 @@ from src.sd_monitor import SDCardInfo
 from src.stats_tracker import StatsTracker
 from src.upload_manager import UploadManager
 
-
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -299,7 +298,7 @@ def _make_patched_init(config_path: Path, staging_dir: Path):
 
     def patched_init(self):
         QMainWindow.__init__(self)
-        self.setWindowTitle("DFN Image Uploader")
+        self.setWindowTitle("Drone -> Cloud")
         self.setMinimumSize(860, 620)
 
         self.state_manager = StateManager()

--- a/tests/test_uploader_ui.py
+++ b/tests/test_uploader_ui.py
@@ -24,7 +24,6 @@ from src.state_manager import StateManager
 from src.stats_tracker import StatsTracker
 from src.uploader import UploaderWindow, _BANNER_TEXT, apply_stylesheet
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -36,7 +35,7 @@ def _make_patched_init(config_path: Path, staging_dir: Path):
 
     def patched_init(self):
         QMainWindow.__init__(self)
-        self.setWindowTitle("DFN Image Uploader")
+        self.setWindowTitle("Drone -> Cloud")
         self.setMinimumSize(1000, 820)
 
         self.state_manager = StateManager()


### PR DESCRIPTION
## What changed

- Rename app display name from "DFN Image Uploader" to "Drone -> Cloud"
- Add subtitle header: "Batch upload drone images to find.gfo.rocks"
- Rename launcher script to `drone_to_cloud`
- Rename PyInstaller build artifacts to `DroneToCloud`
- Update README and deployment docs for the new name
- Clean up app-describing docstrings

Closes #21
